### PR TITLE
Add magic functions

### DIFF
--- a/examples/example_magic_funcs.ipynb
+++ b/examples/example_magic_funcs.ipynb
@@ -1,0 +1,150 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import topotoolbox as topo\n",
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Iteratinf through dem:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dem = topo.GridObject.gen_random_bool(rows=4, columns=4)\n",
+    "for i in dem:\n",
+    "    print(i)\n",
+    "\n",
+    "print(dem[2][2])\n",
+    "dem[2][2] = 2\n",
+    "print(dem[2][2])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Comparing dems:\n",
+    "- `>`, `<`, `>=`, `<=`\n",
+    "- and: `&`\n",
+    "- or: `|`\n",
+    "- xor: `^`\n",
+    "\n",
+    "(in the binary plots, black = true)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dem1 = topo.GridObject.gen_random(rows=32, columns=32, hillsize=24)\n",
+    "dem2 = topo.GridObject.gen_random(rows=32, columns=32, hillsize=32)\n",
+    "\n",
+    "fig, (ax1, ax2, ax3, ax4, ax5, ax6) = plt.subplots(1, 6, figsize=(14,4))\n",
+    "im1 = ax1.imshow(dem1.z, cmap='terrain')\n",
+    "ax1.set_title('dem1')\n",
+    "im2 = ax2.imshow(dem2.z, cmap='terrain')\n",
+    "ax2.set_title('dem2')\n",
+    "\n",
+    "im3 = ax3.imshow((dem1 > dem2).z, cmap='binary')\n",
+    "ax3.set_title('>')\n",
+    "im4 = ax4.imshow((dem1 < dem2).z, cmap='binary')\n",
+    "ax4.set_title('<')\n",
+    "im5 = ax5.imshow((dem1 >= dem2).z, cmap='binary')\n",
+    "ax5.set_title('>=')\n",
+    "im6 = ax6.imshow((dem1 <= dem2).z, cmap='binary')\n",
+    "ax6.set_title('<=')\n",
+    "\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dem1 = topo.GridObject.gen_random_bool()\n",
+    "dem2 = topo.GridObject.gen_random_bool()\n",
+    "\n",
+    "fig, (ax1, ax2, ax3, ax4, ax5) = plt.subplots(1, 5, figsize=(12,4))\n",
+    "im1 = ax1.imshow(dem1.z, cmap='binary')\n",
+    "ax1.set_title('dem1')\n",
+    "im2 = ax2.imshow(dem2.z, cmap='binary')\n",
+    "ax2.set_title('dem2')\n",
+    "\n",
+    "im3 = ax3.imshow((dem1 & dem2).z, cmap='binary')\n",
+    "ax3.set_title('and')\n",
+    "im4 = ax4.imshow((dem1 | dem2).z, cmap='binary')\n",
+    "ax4.set_title('or')\n",
+    "im5 = ax5.imshow((dem1 ^ dem2).z, cmap='binary')\n",
+    "ax5.set_title('xor')\n",
+    "\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Adding two dems and adding a int to all cells of a dem: (works the same way when using `-`, `*` or `/`)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dem1 = topo.GridObject.gen_random(rows=32, columns=32, hillsize=32)\n",
+    "dem2 = topo.GridObject.gen_random(rows=32, columns=32, hillsize=16)\n",
+    "\n",
+    "fig, (ax1, ax2, ax3) = plt.subplots(1, 3)\n",
+    "ax1.imshow(dem1.z, cmap='terrain')\n",
+    "ax2.imshow(dem2.z, cmap='terrain')\n",
+    "\n",
+    "ax3.imshow((dem1 + dem2).z, cmap='terrain')\n",
+    "plt.show()\n",
+    "\n",
+    "print('dem3:\\n', dem1.z)\n",
+    "print('dem3 + 100:\\n', (dem1 + 100).z)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/src/topotoolbox/grid_object.py
+++ b/src/topotoolbox/grid_object.py
@@ -1,13 +1,17 @@
 import numpy as np
 import rasterio
+import random
 
 from .gridmixins.info import InfoMixin
 from .gridmixins.fillsinks import FillsinksMixin
+from .gridmixins.magic import MagicMixin
+
 
 
 class GridObject(
         InfoMixin,
-        FillsinksMixin
+        FillsinksMixin,
+        MagicMixin
 ):
 
     def __init__(self, path=None):
@@ -57,3 +61,21 @@ class GridObject(
     @classmethod
     def gen_empty(cls):
         pass
+
+    @classmethod
+    def gen_random_bool(cls, rows=32, columns=32, cellsize=10):
+        bool_array = np.empty((rows, columns), dtype=np.float32)
+
+        for y in range(0, rows):
+            for x in range(0, columns):
+                bool_array[x][y] = random.choice([0, 1])
+
+        instance = cls(None)
+        instance.path = None
+        instance.z = bool_array
+        instance.rows = rows
+        instance.columns = columns
+        instance.cellsize = cellsize
+
+        return instance
+

--- a/src/topotoolbox/gridmixins/magic.py
+++ b/src/topotoolbox/gridmixins/magic.py
@@ -1,8 +1,6 @@
 import numpy as np
 import copy
 
-# TODO: decide
-
 
 class MagicMixin():
     def __eq__(self, other):

--- a/src/topotoolbox/gridmixins/magic.py
+++ b/src/topotoolbox/gridmixins/magic.py
@@ -1,0 +1,238 @@
+import numpy as np
+import copy
+
+# TODO: decide
+
+
+class MagicMixin():
+    def __eq__(self, other):
+        dem = copy.deepcopy(self)
+
+        if not isinstance(other, self.__class__):
+            raise TypeError("Can only compare two GridObjects.")
+
+        if self.columns != other.columns or self.rows != other.rows:
+            raise ValueError("Both GridObjects have to be the same size.")
+
+        for x in range(0, self.columns):
+            for y in range(0, self.rows):
+
+                dem.z[x][y] = self.z[x][y] == other.z[x][y]
+
+        return dem
+
+    def __ne__(self, other):
+        dem = copy.deepcopy(self)
+
+        if not isinstance(other, self.__class__):
+            raise TypeError("Can only compare two GridObjects.")
+
+        if self.columns != other.columns or self.rows != other.rows:
+            raise ValueError("Both GridObjects have to be the same size.")
+
+        for x in range(0, self.columns):
+            for y in range(0, self.rows):
+
+                dem.z[x][y] = self.z[x][y] != other.z[x][y]
+
+        return dem
+
+    def __gt__(self, other):
+        dem = copy.deepcopy(self)
+
+        if not isinstance(other, self.__class__):
+            raise TypeError("Can only compare two GridObjects.")
+
+        if self.columns != other.columns or self.rows != other.rows:
+            raise ValueError("Both GridObjects have to be the same size.")
+
+        for x in range(0, self.columns):
+            for y in range(0, self.rows):
+
+                dem.z[x][y] = self.z[x][y] > other.z[x][y]
+
+        return dem
+
+    def __lt__(self, other):
+        dem = copy.deepcopy(self)
+
+        if not isinstance(other, self.__class__):
+            raise TypeError("Can only compare two GridObjects.")
+
+        if self.columns != other.columns or self.rows != other.rows:
+            raise ValueError("Both GridObjects have to be the same size.")
+
+        for x in range(0, self.columns):
+            for y in range(0, self.rows):
+
+                dem.z[x][y] = self.z[x][y] < other.z[x][y]
+
+        return dem
+
+    def __ge__(self, other):
+        dem = copy.deepcopy(self)
+
+        if not isinstance(other, self.__class__):
+            raise TypeError("Can only compare two GridObjects.")
+
+        if self.columns != other.columns or self.rows != other.rows:
+            raise ValueError("Both GridObjects have to be the same size.")
+
+        for x in range(0, self.columns):
+            for y in range(0, self.rows):
+
+                dem.z[x][y] = self.z[x][y] >= other.z[x][y]
+
+        return dem
+
+    def __le__(self, other):
+        dem = copy.deepcopy(self)
+
+        if not isinstance(other, self.__class__):
+            raise TypeError("Can only compare two GridObjects.")
+
+        if self.columns != other.columns or self.rows != other.rows:
+            raise ValueError("Both GridObjects have to be the same size.")
+
+        for x in range(0, self.columns):
+            for y in range(0, self.rows):
+
+                dem.z[x][y] = self.z[x][y] <= other.z[x][y]
+
+        return dem
+
+    def __add__(self, other):
+        dem = copy.copy(self)
+
+        if isinstance(other, self.__class__):
+            dem.z = self.z + other.z
+            return dem
+
+        else:
+            dem.z = self.z + other
+            return dem
+
+    def __sub__(self, other):
+        dem = copy.copy(self)
+
+        if isinstance(other, self.__class__):
+            dem.z = self.z - other.z
+            return dem
+
+        else:
+            dem.z = self.z - other
+            return dem
+
+    def __mul__(self, other):
+        dem = copy.copy(self)
+
+        if isinstance(other, self.__class__):
+            dem.z = self.z * other.z
+            return dem
+
+        else:
+            dem.z = self.z * other
+            return dem
+
+    def __div__(self, other):
+        dem = copy.copy(self)
+
+        if isinstance(other, self.__class__):
+            dem.z = self.z / other.z
+            return dem
+
+        else:
+            dem.z = self.z / other
+            return dem
+
+    def __and__(self, other):
+        dem = copy.deepcopy(self)
+
+        if not isinstance(other, self.__class__):
+            raise TypeError("Can only compare two GridObjects.")
+
+        if self.columns != other.columns or self.rows != other.rows:
+            raise ValueError("Both GridObjects have to be the same size.")
+
+        for x in range(0, self.columns):
+            for y in range(0, self.rows):
+
+                if (self.z[x][y] not in [0, 1]
+                        or other.z[x][y] not in [0, 1]):
+
+                    raise ValueError(
+                        "Invalid cell value. 'and' can only compare True (1) and False (0) values.")
+
+                dem.z[x][y] = (int(self.z[x][y]) & int(other.z[x][y]))
+
+        return dem
+
+    def __or__(self, other):
+        dem = copy.deepcopy(self)
+
+        if not isinstance(other, self.__class__):
+            raise TypeError("Can only compare two GridObjects.")
+
+        if self.columns != other.columns or self.rows != other.rows:
+            raise ValueError("Both GridObjects have to be the same size.")
+
+        for x in range(0, self.columns):
+            for y in range(0, self.rows):
+
+                if (self.z[x][y] not in [0, 1]
+                        or other.z[x][y] not in [0, 1]):
+
+                    raise ValueError(
+                        "Invalid cell value. 'or' can only compare True (1) and False (0) values.")
+
+                dem.z[x][y] = (int(self.z[x][y]) | int(other.z[x][y]))
+
+        return dem
+
+    def __xor__(self, other):
+        dem = copy.deepcopy(self)
+
+        if not isinstance(other, self.__class__):
+            raise TypeError("Can only compare two GridObjects.")
+
+        if self.columns != other.columns or self.rows != other.rows:
+            raise ValueError("Both GridObjects have to be the same size.")
+
+        for x in range(0, self.columns):
+            for y in range(0, self.rows):
+
+                if (self.z[x][y] not in [0, 1]
+                        or other.z[x][y] not in [0, 1]):
+
+                    raise ValueError(
+                        "Invalid cell value. 'xor' can only compare True (1) and False (0) values.")
+
+                dem.z[x][y] = (int(self.z[x][y]) ^ int(other.z[x][y]))
+
+        return dem
+
+    def __len__(self):
+        # TODO: decide if len() should return len(np.array) or shape of np.array
+        return len(self.z)
+
+    def __iter__(self):
+        return iter(self.z)
+
+    def __getitem__(self, index):
+        return self.z[index]
+
+    def __setitem__(self, index, value):
+        try:
+            value = np.float32(value)
+        except:
+            raise TypeError(
+                value, " not can't be converted to float32.") from None
+
+        self.z[index] = value
+
+    def __delitem__(self, index):
+        # TODO: do we even need this function?
+        self.z = np.delete(self.z, index, axis=0)
+
+    def __array__(self):
+        return self.z


### PR DESCRIPTION
In this version, I implemented the previously discussed "magic" functions. Turns out the `r` and `i` versions (as noted in #17 ) are not needed, but instead of `__comp__` all the functions for comparing had to be implemented on their own.

I am using a `copy.deepcopy()` when returning the new dem (after computing `and`, for example) since only doing a shallow copy resulted in overwriting `dem1` when doing this, for example: `dem3 = dem1 & dem2`

- for `__len__` we need to decide, if we want to return the number of elements in the first dimension (like it works for the np.array). or i we want to return the shape of the dem (rows, cols). 
- for `__delitem__` I am questioning if we need it at all. I can't think of a situation, where the user would want to delete a specific row of their dem.

I included the notebook `examples/example_magic_funcs.ipynb` which provides simple examples that showcase functionality. Feel free to play around with those a bit. 
