### PR TITLE
Windows Installation Guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,65 +8,66 @@ Python interface to TopoToolbox.
 
 - **Installing from .whl file**
 
-    Make sure to choose the appropriate file for your OS. For Linux the file name should contain something like: `linux_x86_64`
+	Make sure to choose the appropriate file for your OS. For Linux, the file name should contain something like: `linux_x86_64`
 
-    ```bash
-    pip install dist_name.whl
-    ```
+	```bash
+	pip install dist_name.whl
+	```
 
-- **Installing directly from the reposetory:**
+- **Installing directly from the repository:**
 
-    ```bash
-    cd path/to/pytopotoolbox
-    pip install .
-    ```
+	```bash
+	cd path/to/pytopotoolbox
+	pip install .
+	```
 
 - **Generating distribution archives**
 
-    ```bash
-    cd path/to/pytopotoolbox
-    python3 -m pip install --upgrade build
-    python3 -m build
-    ```
+	```bash
+	cd path/to/pytopotoolbox
+	python3 -m pip install --upgrade build
+	python3 -m build
+	```
 
 ### Windows
 
 - **Installing from .whl file**
 
-    Make sure to choose the appropriate file for your OS. For Windows the file name should contain something like: `win_amd64`. Python and pip should also be installed.
+	Make sure to choose the appropriate file for your OS. For Windows, the file name should contain something like: `win_amd64`. Python and pip should also be installed.
 
-    ```bash
-    pip install dist_name.whl
-    ```
+	```bash
+	pip install dist_name.whl
+	```
 
-- **Installing directly from the reposetory:**
+- **Installing directly from the repository:**
 
-    Since there are C/C++ files that need to be compiled in order to build the package, there are a few extra steps to take.
+	Since there are C/C++ files that need to be compiled in order to build the package, there are a few extra steps to take.
 
-    1. Install python and pip
-    2. Install the [Developer Command Prompt for VS 2022](https://visualstudio.microsoft.com/downloads/).
-        - Scroll down to '_All Downloads_'
-        - open '_Tools for Visual Studio_'
-        - download '_Build Tools for Visual Studio 2022_'
-        - install it while including the '_Desktop development with C++_' workload
-    3. To ensure the complier is working with 64-bit architecture, that is necssesry for python, **open 'x64 Native Tools Command Prompt for VS 2022'** instead of the '_Developer Command Prompt_' that defaults to 32-bit architecture.
-    4. In the newly opened terminal, run:
+	1. Install python and pip
+	2. Install the [Developer Command Prompt for VS 2022](https://visualstudio.microsoft.com/downloads/).
+    	- Scroll down to '_All Downloads_'
+    	- open '_Tools for Visual Studio_'
+    	- download '_Build Tools for Visual Studio 2022_'
+    	- install it while including the '_Desktop development with C++_' workload
+	3. To ensure the compiler is working with 64-bit architecture, that is necessary for python, **open 'x64 Native Tools Command Prompt for VS 2022'** instead of the '_Developer Command Prompt_' that defaults to 32-bit architecture.
+	4. In the newly opened terminal, run:
 
-        ```bash
-        cd path\to\pytopotoolbox
-        pip install .
-        ```
+    	```bash
+    	cd path\to\pytopotoolbox
+    	pip install .
+    	```
 
 - **Generating distribution archives**
 
-    Open the 'x64 Native Tools Command Prompt for VS 2022' Terminal and run:
+	Open the 'x64 Native Tools Command Prompt for VS 2022' Terminal and run:
 
-    ```bash
-    cd path\to\pytopotoolbox
-    py -m pip install --upgrade build
-    py -m build
-    ```
+	```bash
+	cd path\to\pytopotoolbox
+	py -m pip install --upgrade build
+	py -m build
+	```
 
 ### Mac
 
 [work in progress]
+

--- a/README.md
+++ b/README.md
@@ -2,44 +2,71 @@
 
 Python interface to TopoToolbox.
 
-## Guide
+## Generating/Installing distribution archives
 
-Temporary guide for the functionality of the package. For Windows replace "python3" with "py".
+### Linux
 
-### Generate distribution archives
+- **Installing from .whl file**
 
-Before building the archive, make sure the `libtopotoolbox.so` has been added to `/pytopotoolbox/src/topotoolbox/`.
-Generates a .whl and .tar.gz which then can be used to install package with pip.
-These Files can be distributed with PyPi or downloaded directly.
+    Make sure to choose the appropriate file for your OS. For Linux the file name should contain something like: `linux_x86_64`
 
-```bash
-cd path/to/pytopotoolbox
-python3 -m pip install --upgrade build
-python3 -m build
-```
+    ```bash
+    pip install dist_name.whl
+    ```
 
-### Installing distribution archives
+- **Installing directly from the reposetory:**
 
-Use "--force-reinstall" to overwrite previous install.
+    ```bash
+    cd path/to/pytopotoolbox
+    pip install .
+    ```
 
-```bash
-pip install dist_name.whl
-```
+- **Generating distribution archives**
 
-### Installing from repository
+    ```bash
+    cd path/to/pytopotoolbox
+    python3 -m pip install --upgrade build
+    python3 -m build
+    ```
 
-If want to install the package directly from the repository without first generating a ".whl" file.
+### Windows
 
-```bash
-cd path/to/pytopotoolbox
-pip install .
-```
+- **Installing from .whl file**
 
-### Unittest
+    Make sure to choose the appropriate file for your OS. For Windows the file name should contain something like: `win_amd64`. Python and pip should also be installed.
 
-How to run a single unittest:
+    ```bash
+    pip install dist_name.whl
+    ```
 
-```bash
-cd path/to/pytopotoolbox
-python3 -m tests.filename 
-```
+- **Installing directly from the reposetory:**
+
+    Since there are C/C++ files that need to be compiled in order to build the package, there are a few extra steps to take.
+
+    1. Install python and pip
+    2. Install the [Developer Command Prompt for VS 2022](https://visualstudio.microsoft.com/downloads/).
+        - Scroll down to '_All Downloads_'
+        - open '_Tools for Visual Studio_'
+        - download '_Build Tools for Visual Studio 2022_'
+        - install it while including the '_Desktop development with C++_' workload
+    3. To ensure the complier is working with 64-bit architecture, that is necssesry for python, **open 'x64 Native Tools Command Prompt for VS 2022'** instead of the '_Developer Command Prompt_' that defaults to 32-bit architecture.
+    4. In the newly opened terminal, run:
+
+        ```bash
+        cd path\to\pytopotoolbox
+        pip install .
+        ```
+
+- **Generating distribution archives**
+
+    Open the 'x64 Native Tools Command Prompt for VS 2022' Terminal and run:
+
+    ```bash
+    cd path\to\pytopotoolbox
+    py -m pip install --upgrade build
+    py -m build
+    ```
+
+### Mac
+
+[work in progress]

--- a/README.md
+++ b/README.md
@@ -8,66 +8,65 @@ Python interface to TopoToolbox.
 
 - **Installing from .whl file**
 
-	Make sure to choose the appropriate file for your OS. For Linux, the file name should contain something like: `linux_x86_64`
+    Make sure to choose the appropriate file for your OS. For Linux, the file name should contain something like: `linux_x86_64`
 
-	```bash
-	pip install dist_name.whl
-	```
+    ```bash
+    pip install dist_name.whl
+    ```
 
 - **Installing directly from the repository:**
 
-	```bash
-	cd path/to/pytopotoolbox
-	pip install .
-	```
+    ```bash
+    cd path/to/pytopotoolbox
+    pip install .
+    ```
 
 - **Generating distribution archives**
 
-	```bash
-	cd path/to/pytopotoolbox
-	python3 -m pip install --upgrade build
-	python3 -m build
-	```
+    ```bash
+    cd path/to/pytopotoolbox
+    python3 -m pip install --upgrade build
+    python3 -m build
+    ```
 
 ### Windows
 
 - **Installing from .whl file**
 
-	Make sure to choose the appropriate file for your OS. For Windows, the file name should contain something like: `win_amd64`. Python and pip should also be installed.
+    Make sure to choose the appropriate file for your OS. For Windows, the file name should contain something like: `win_amd64`. Python and pip should also be installed.
 
-	```bash
-	pip install dist_name.whl
-	```
+    ```bash
+    pip install dist_name.whl
+    ```
 
 - **Installing directly from the repository:**
 
-	Since there are C/C++ files that need to be compiled in order to build the package, there are a few extra steps to take.
+    Since there are C/C++ files that need to be compiled in order to build the package, there are a few extra steps to take.
 
-	1. Install python and pip
-	2. Install the [Developer Command Prompt for VS 2022](https://visualstudio.microsoft.com/downloads/).
-    	- Scroll down to '_All Downloads_'
-    	- open '_Tools for Visual Studio_'
-    	- download '_Build Tools for Visual Studio 2022_'
-    	- install it while including the '_Desktop development with C++_' workload
-	3. To ensure the compiler is working with 64-bit architecture, that is necessary for python, **open 'x64 Native Tools Command Prompt for VS 2022'** instead of the '_Developer Command Prompt_' that defaults to 32-bit architecture.
-	4. In the newly opened terminal, run:
+    1. Install python and pip
+    2. Install the [Developer Command Prompt for VS 2022](https://visualstudio.microsoft.com/downloads/).
+        - Scroll down to '_All Downloads_'
+        - open '_Tools for Visual Studio_'
+        - download '_Build Tools for Visual Studio 2022_'
+        - install it while including the '_Desktop development with C++_' workload
+    3. To ensure the compiler is working with 64-bit architecture, that is necessary for python, **open 'x64 Native Tools Command Prompt for VS 2022'** instead of the '_Developer Command Prompt_' that defaults to 32-bit architecture.
+    4. In the newly opened terminal, run:
 
-    	```bash
-    	cd path\to\pytopotoolbox
-    	pip install .
-    	```
+        ```bash
+        cd path\to\pytopotoolbox
+        pip install .
+        ```
 
 - **Generating distribution archives**
 
-	Open the 'x64 Native Tools Command Prompt for VS 2022' Terminal and run:
+    Open the 'x64 Native Tools Command Prompt for VS 2022' Terminal and run:
 
-	```bash
-	cd path\to\pytopotoolbox
-	py -m pip install --upgrade build
-	py -m build
-	```
+    ```bash
+    cd path\to\pytopotoolbox
+    py -m pip install --upgrade build
+    py -m build
+    ```
 
 ### Mac
 
 [work in progress]
-

--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@ Python interface to TopoToolbox.
 
 ## Generating/Installing distribution archives
 
+For any operating system, install the following:
+
+- **Python**
+- **pip**
+- **Git** (only when _building_ the package yourself)
+
 ### Linux
 
 - **Installing from .whl file**
@@ -33,7 +39,7 @@ Python interface to TopoToolbox.
 
 - **Installing from .whl file**
 
-    Make sure to choose the appropriate file for your OS. For Windows, the file name should contain something like: `win_amd64`. Python and pip should also be installed.
+    Make sure to choose the appropriate file for your OS. For Windows, the file name should contain something like: `win_amd64`.
 
     ```bash
     pip install dist_name.whl
@@ -43,14 +49,13 @@ Python interface to TopoToolbox.
 
     Since there are C/C++ files that need to be compiled in order to build the package, there are a few extra steps to take.
 
-    1. Install python and pip
-    2. Install the [Developer Command Prompt for VS 2022](https://visualstudio.microsoft.com/downloads/).
+    1. Install the [Developer Command Prompt for VS 2022](https://visualstudio.microsoft.com/downloads/).
         - Scroll down to '_All Downloads_'
         - open '_Tools for Visual Studio_'
         - download '_Build Tools for Visual Studio 2022_'
         - install it while including the '_Desktop development with C++_' workload
-    3. To ensure the compiler is working with 64-bit architecture, that is necessary for python, **open 'x64 Native Tools Command Prompt for VS 2022'** instead of the '_Developer Command Prompt_' that defaults to 32-bit architecture.
-    4. In the newly opened terminal, run:
+    2. To ensure the compiler is working with 64-bit architecture, that is necessary for python, **open 'x64 Native Tools Command Prompt for VS 2022'** instead of the '_Developer Command Prompt_' that defaults to 32-bit architecture.
+    3. In the newly opened terminal, run:
 
         ```bash
         cd path\to\pytopotoolbox


### PR DESCRIPTION
Reorganized Readme.md structure. The Linux Guide is mostly the same as before.

1. **For Windows:**
It took quite a while to get Windows to build the package while not crashing during the C/C++ compiling stage. But now that I have got it running, it's pretty straight forward. To make sure that the guide actually works, it would be nice if one of you could follow the steps in the guide, build the package and then just run one of the example files to verify functionality. 

2. **For Mac**
Since I don't own an Apple Laptop, I can't check if the installation works there too. I assume it works the same as on Linux, but I have no way of knowing. I'll add an issue to track this.  (#26 )