### PR TITLE
Add basic CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,4 +17,6 @@ jobs:
         with:
           python-version: '3.10'
       - name: Install package
-        run: python -m pip install .
+        run: python -m pip install .[opensimplex]
+      - name: Tests
+        run: python -c "import topotoolbox as topo; dem = topo.GridObject.gen_random(); assert (dem.fillsinks() >= dem).z.all()"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,20 @@
+name: CI
+on:
+  pull_request:    
+  push:
+    branches: ["main"]
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+      - name: Install package
+        run: python -m pip install .

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,12 +11,13 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout package
+        uses: actions/checkout@v4
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
           python-version: '3.10'
       - name: Install package
         run: python -m pip install .[opensimplex]
-      - name: Tests
+      - name: Test package
         run: python -c "import topotoolbox as topo; dem = topo.GridObject.gen_random(); assert (dem.fillsinks() >= dem).z.all()"


### PR DESCRIPTION
Partially addresses #27 

This adds a basic CI workflow that builds the package on Ubuntu, macOS and Windows using `pip install .[opensimplex]` and then runs a "test" that generates a random DEM, fills sinks and checks that the filled DEM is greater than or equal to the original one (this is one of the properties that we test in libtopotoolbox).

Since this build seems to work on GitHub Actions, I will probably merge this ASAP, so we have a starting point. Then I think we need to add:

1. Code formatting checks
2. Lints
3. Automated tests