### PR TITLE
Provide example data

### DIFF
--- a/examples/test_load_dem.ipynb
+++ b/examples/test_load_dem.ipynb
@@ -6,9 +6,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import topotoolbox as topo\n",
-    "\n",
-    "import matplotlib.pyplot as plt"
+    "import topotoolbox as topo"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(topo.get_dem_names())"
    ]
   },
   {
@@ -19,6 +26,25 @@
    "source": [
     "dem = topo.load_dem(\"taiwan\")\n",
     "dem.info()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(topo.get_cache_contents())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "topo.clear_cache()\n",
+    "print(topo.get_cache_contents())"
    ]
   }
  ],

--- a/examples/test_load_dem.ipynb
+++ b/examples/test_load_dem.ipynb
@@ -1,0 +1,57 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import topotoolbox as topo\n",
+    "\n",
+    "import matplotlib.pyplot as plt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "path: https://raw.githubusercontent.com/wschwanghart/DEMs/master/tibet.tif\n",
+      "rows: 1259\n",
+      "cols: 1793\n",
+      "cellsize: 90.0\n"
+     ]
+    }
+   ],
+   "source": [
+    "dem = topo.load_dem(\"tibet\")\n",
+    "dem.info()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/examples/test_load_dem.ipynb
+++ b/examples/test_load_dem.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -13,22 +13,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "path: https://raw.githubusercontent.com/wschwanghart/DEMs/master/tibet.tif\n",
-      "rows: 1259\n",
-      "cols: 1793\n",
-      "cellsize: 90.0\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "dem = topo.load_dem(\"tibet\")\n",
+    "dem = topo.load_dem(\"taiwan\")\n",
     "dem.info()"
    ]
   }

--- a/src/topotoolbox/__init__.py
+++ b/src/topotoolbox/__init__.py
@@ -1,1 +1,2 @@
 from .grid_object import GridObject
+from .utils import *

--- a/src/topotoolbox/grid_object.py
+++ b/src/topotoolbox/grid_object.py
@@ -19,23 +19,21 @@ class GridObject(
         MagicMixin
 ):
     """A class containing all information of a Digital Elevation Model (DEM).
-    This class combines mixins to provide various functionalities for working with DEMs.
-
-    Args:
-        InfoMixin: A mixin class providing methods to retrieve information about the DEM.
-        FillsinksMixin: A mixin class providing a method to fill sinks in the DEM.
-        MagicMixin: A mixin class providing magical methods for the DEM.
+    This class combines mixins to provide various functionalities 
+    for working with DEMs.
     """
 
     def __init__(self, path: Union[str, None] = None) -> None:
         """Initialize a GridObject instance.
 
         Args:
-            path (str, optional): The path to the raster file. Defaults to None.
+            path (str, optional): The path to the raster file. 
+            Defaults to None.
 
         Raises:
             TypeError: If an invalid type is passed as the `path`.
-            ValueError: If an error occurs while processing the `path` argument.
+            ValueError: If an error occurs while processing 
+            the `path` argument.
         """
 
         if path is not None:
@@ -66,7 +64,8 @@ class GridObject(
     def gen_random(
             cls, hillsize: int = 24, rows: int = 128, columns: int = 128,
             cellsize: float = 10.0) -> 'GridObject':
-        """Generate a GridObject instance that is generated with OpenSimplex noise.
+        """Generate a GridObject instance that is generated with
+        OpenSimplex noise.
 
         Args:
             hillsize (int, optional): Controls the "smoothness" of the 
@@ -80,16 +79,17 @@ class GridObject(
             ImportError: If OpenSimplex has not been installed.
 
         Returns:
-            GridObject: An instance of GridObject with randomly generated values.
+            GridObject: An instance of GridObject with randomly
+            generated values.
         """
 
         try:
-            import opensimplex as simplex
+            import opensimplex as simplex  # pylint: disable=C0415
 
         except ImportError:
-            raise ImportError(
-                """For gen_random to work, use \"pip install topotoolbox[opensimplex]\"
-                  or \"pip install .[opensimplex]\"""") from None
+            err = ("For gen_random to work, use \"pip install topotool" +
+                   "box[opensimplex]\" or \"pip install .[opensimplex]\"")
+            raise ImportError(err) from None
 
         noise_array = np.empty((rows, columns), dtype=np.float32)
         for y in range(0, rows):
@@ -116,14 +116,16 @@ class GridObject(
 
     @classmethod
     def gen_random_bool(
-            cls, rows: int = 32, columns: int = 32, cellsize: float = 10.0) -> 'GridObject':
+            cls, rows: int = 32, columns: int = 32, cellsize: float = 10.0
+    ) -> 'GridObject':
         """Generate a GridObject instance that caontains only randomly
         generated Boolean values. 
 
         Args:
             rows (int, optional): Number of rows. Defaults to 32.
             columns (int, optional): Number of columns. Defaults to 32.
-            cellsize (float, optional): size of each cell in the grid. Defaults to 10.
+            cellsize (float, optional): size of each cell in the grid. 
+            Defaults to 10.
 
         Returns:
             GridObject: _description_

--- a/src/topotoolbox/grid_object.py
+++ b/src/topotoolbox/grid_object.py
@@ -118,7 +118,7 @@ class GridObject(
     def gen_random_bool(
             cls, rows: int = 32, columns: int = 32, cellsize: float = 10.0
     ) -> 'GridObject':
-        """Generate a GridObject instance that caontains only randomly
+        """Generate a GridObject instance that contains only randomly
         generated Boolean values. 
 
         Args:

--- a/src/topotoolbox/grid_object.py
+++ b/src/topotoolbox/grid_object.py
@@ -1,15 +1,15 @@
 """This module contains the GridObject class.
 """
+
 import random
 from typing import Union
 
 import numpy as np
 import rasterio
 
-from .gridmixins.fillsinks import FillsinksMixin
-from .gridmixins.info import InfoMixin
-from .gridmixins.magic import MagicMixin
-from .gridmixins.identifyflats import IdentifyflatsMixin
+from .gridmixins import *  # pylint: disable=W0401
+
+__all__ = ['GridObject']
 
 
 class GridObject(

--- a/src/topotoolbox/gridmixins/__init__.py
+++ b/src/topotoolbox/gridmixins/__init__.py
@@ -1,0 +1,6 @@
+from .fillsinks import FillsinksMixin
+from .info import InfoMixin
+from .magic import MagicMixin
+from .identifyflats import IdentifyflatsMixin
+
+__all__ = ['FillsinksMixin', 'InfoMixin', 'MagicMixin', 'IdentifyflatsMixin']

--- a/src/topotoolbox/gridmixins/identifyflats.py
+++ b/src/topotoolbox/gridmixins/identifyflats.py
@@ -8,7 +8,7 @@ from .._grid import grid_identifyflats  # pylint: disable=import-error
 
 
 class IdentifyflatsMixin():
-    """Mixin class containing Indentifyflats.
+    """Mixin class containing Identifyflats.
     """
 
     def identifyflats(

--- a/src/topotoolbox/gridmixins/identifyflats.py
+++ b/src/topotoolbox/gridmixins/identifyflats.py
@@ -1,3 +1,5 @@
+"""This module contains the Mixin class IdentifyflatsMixin for the GridObject.
+"""
 import copy
 
 import numpy as np
@@ -6,24 +8,32 @@ from .._grid import grid_identifyflats  # pylint: disable=import-error
 
 
 class IdentifyflatsMixin():
+    """Mixin class containing Indentifyflats.
+    """
 
-    def identifyflats(self, raw=False, output=['sills', 'flats']) -> tuple:
+    def identifyflats(
+            self, raw: bool = False, output: list[str] = None) -> tuple:
         """
         Identifies flats and sills in a digital elevation model (DEM).
 
         Args:
             raw (bool): If True, returns the raw output grid as np.ndarray. 
-                Defaults to False.
+            Defaults to False.
             output (list): List of strings indicating desired output types.
-                Possible values are 'sills', 'flats'. Defaults to ['sills', 'flats'].
+            Possible values are 'sills', 'flats'. 
+            Defaults to ['sills', 'flats'].
 
         Returns:
-            tuple: A tuple containing copies of the DEM with identified flats and/or sills.
+            tuple: A tuple containing copies of the DEM with identified
+            flats and/or sills.
 
         Note:
-            Flats are identified as 1s, sills as 2s and presills as 5s (since they are also flats)
-              in the output grid. Only relevant when using raw=True.
+            Flats are identified as 1s, sills as 2s and presills as 5s 
+            (since they are also flats) in the output grid.
+            Only relevant when using raw=True.
         """
+        if output is None:
+            output = ['sills', 'flats']
 
         dem = self.z.astype(np.float32)
         output_grid = np.zeros_like(dem).astype(np.int32)

--- a/src/topotoolbox/gridmixins/magic.py
+++ b/src/topotoolbox/gridmixins/magic.py
@@ -161,7 +161,8 @@ class MagicMixin():
                         or other.z[x][y] not in [0, 1]):
 
                     raise ValueError(
-                        "Invalid cell value. 'and' can only compare True (1) and False (0) values.")
+                        "Invalid cell value. 'and' can only compare " +
+                        "True (1) and False (0) values.")
 
                 dem.z[x][y] = (int(self.z[x][y]) & int(other.z[x][y]))
 
@@ -183,7 +184,8 @@ class MagicMixin():
                         or other.z[x][y] not in [0, 1]):
 
                     raise ValueError(
-                        "Invalid cell value. 'or' can only compare True (1) and False (0) values.")
+                        "Invalid cell value. 'or' can only compare True (1)" +
+                        " and False (0) values.")
 
                 dem.z[x][y] = (int(self.z[x][y]) | int(other.z[x][y]))
 
@@ -205,7 +207,8 @@ class MagicMixin():
                         or other.z[x][y] not in [0, 1]):
 
                     raise ValueError(
-                        "Invalid cell value. 'xor' can only compare True (1) and False (0) values.")
+                        "Invalid cell value. 'xor' can only compare True (1)" +
+                        " and False (0) values.")
 
                 dem.z[x][y] = (int(self.z[x][y]) ^ int(other.z[x][y]))
 

--- a/src/topotoolbox/utils.py
+++ b/src/topotoolbox/utils.py
@@ -3,15 +3,14 @@
 import sys
 import os
 
-from urllib.request import urlretrieve
+from urllib.request import urlopen, urlretrieve
 
 from .grid_object import GridObject
 
 __all__ = ["load_dem", "get_dem_names", "read_tif"]
 
-DEM_SOURCE = "https://raw.githubusercontent.com/wschwanghart/DEMs/master"
-DEM_NAMES = ['kunashiri', 'perfectworld',
-             'taalvolcano', 'taiwan', 'tibet', 'kedarnath']
+DEM_SOURCE = "https://raw.githubusercontent.com/TopoToolbox/DEMs/master"
+DEM_NAMES = f"{DEM_SOURCE}/dem_names.txt"
 
 
 def read_tif(path: str) -> GridObject:
@@ -28,17 +27,15 @@ def read_tif(path: str) -> GridObject:
 
 def get_dem_names() -> list[str]:
     """Returns a list of provided example Digital Elevation Models (DEMs).
+    Requires internet connection to download available names.
 
     Returns:
-        list: A list of strings, where each string is the name of a DEM.
-
-    Note:
-        If a file with all names is added to the 'wschwanghart/DEMs' 
-        repository, the DEM_NAMES list could be generated dynamically from 
-        that file. This would ensure the list remains up-to-date if the 
-        files ever change.
+        list[str]: A list of strings, where each string is the name of a DEM.
     """
-    return DEM_NAMES
+    with urlopen(DEM_NAMES) as dem_names:
+        dem_names = dem_names.read().decode()
+
+    return dem_names.splitlines()
 
 
 def load_dem(dem: str, cache=True) -> GridObject:
@@ -54,6 +51,10 @@ def load_dem(dem: str, cache=True) -> GridObject:
     Returns:
         GridObject: A GridObject generated from the downloaded dem.
     """
+    if dem not in get_dem_names():
+        err = ("DEM has to be chosen from the list of available DEMs."
+               "Use 'get_dem_names()' to generate list of all available DEMs")
+        raise ValueError(err)
 
     url = f"{DEM_SOURCE}/{dem}.tif"
 

--- a/src/topotoolbox/utils.py
+++ b/src/topotoolbox/utils.py
@@ -1,0 +1,109 @@
+import sys
+import os
+
+from urllib.request import urlretrieve
+
+from .grid_object import GridObject
+
+__all__ = ["load_dem", "get_dem_names"]
+
+DEM_SOURCE = "https://raw.githubusercontent.com/wschwanghart/DEMs/master"
+DEM_NAMES = ['kunashiri', 'perfectworld',
+             'taalvolcano', 'taiwan', 'tibet', 'kedarnath']
+
+
+def get_dem_names():
+    """Returns a list of provided example Digital Elevation Models (DEMs).
+
+    Returns:
+        list: A list of strings, where each string is the name of a DEM.
+
+    Note:
+        If a file with all names is added to the 'wschwanghart/DEMs' repository, 
+        the DEM_NAMES list could be generated dynamically from that file. This would 
+        ensure the list remains up-to-date if the files ever change.
+    """
+    return DEM_NAMES
+
+
+def load_dem(dem: str, cache=True, data_home=None):
+    """Downloads DEM from wschwanghart/DEMs reposetory. 
+    Find possible names by using 'get_dem_names()'
+
+    Args:
+        dem (str): Name of dem about to be downloaded
+        cache (bool, optional): If true the dem will be cached. Defaults to True.
+        data_home (str, optional): optional name of cache. Defaults to None.
+
+    Returns:
+        GridObject: A GridObject generated from the downloaded dem.
+    """
+
+    url = f"{DEM_SOURCE}/{dem}.tif"
+
+    if cache:
+        cache_path = os.path.join(get_save_location(data_home), f"{dem}.tif")
+
+        # only download if not already downloaded
+        if not os.path.exists(cache_path):
+            urlretrieve(url, cache_path)
+
+        full_path = cache_path
+    else:
+        full_path = url
+
+    dem = GridObject(full_path)
+
+    return dem
+
+
+def get_save_location(data_home=None):
+    """Genrates filepath to file saved in cache
+
+    Args:
+        data_home (str, optional): name of directory in cache. Defaults to None
+        which results in "topotoolbox" as name.
+
+    Returns:
+        str: filepath to file saved in cache.
+    """
+    if data_home is None:
+        data_home = cache_dir("topotoolbox")
+
+    # turn ~ shorthand to full path
+    data_home = os.path.expanduser(data_home)
+
+    # create path if it dosnt exsist already
+    if not os.path.exists(data_home):
+        os.makedirs(data_home)
+
+    return data_home
+
+
+def cache_dir(appname=None):
+    """Generates filepath for cache directory.
+
+    Args:
+        appname (str, optional): Optional name for cache reposetory. Defaults to None.
+
+    Returns:
+        str: Path to cache directory.
+    """
+    system = sys.platform
+
+    if system == "win32":
+        path = os.getenv('LOCALAPPDATA')
+        if appname:
+            path = os.path.join(path, appname)
+
+    elif system == 'darwin':
+        path = os.path.expanduser('~/Library/Caches')
+        if appname:
+            path = os.path.join(path, appname)
+
+    else:
+        path = os.getenv(os.path.expanduser('~/.cache'))
+        if appname:
+            path = os.path.join(path, appname)
+
+    return path

--- a/src/topotoolbox/utils.py
+++ b/src/topotoolbox/utils.py
@@ -42,7 +42,7 @@ def get_dem_names() -> list[str]:
 
 
 def load_dem(dem: str, cache=True) -> GridObject:
-    """Downloads DEM from wschwanghart/DEMs reposetory. 
+    """Downloads DEM from wschwanghart/DEMs repository. 
     Find possible names by using 'get_dem_names()'
 
     Args:

--- a/src/topotoolbox/utils.py
+++ b/src/topotoolbox/utils.py
@@ -1,3 +1,5 @@
+"""Provide general utility functions for topotoolbox.
+"""
 import sys
 import os
 
@@ -5,11 +7,23 @@ from urllib.request import urlretrieve
 
 from .grid_object import GridObject
 
-__all__ = ["load_dem", "get_dem_names"]
+__all__ = ["load_dem", "get_dem_names", "read_tif"]
 
 DEM_SOURCE = "https://raw.githubusercontent.com/wschwanghart/DEMs/master"
 DEM_NAMES = ['kunashiri', 'perfectworld',
              'taalvolcano', 'taiwan', 'tibet', 'kedarnath']
+
+
+def read_tif(path: str):
+    """Generate a new GridObject from .tif file.
+
+    Args:
+        path (str): path to .tif file.
+
+    Returns:
+        GridObject: A new GridObject of the .tif file.
+    """
+    return GridObject(path)
 
 
 def get_dem_names():
@@ -26,7 +40,7 @@ def get_dem_names():
     return DEM_NAMES
 
 
-def load_dem(dem: str, cache=True, data_home=None):
+def load_dem(dem: str, cache=True):
     """Downloads DEM from wschwanghart/DEMs reposetory. 
     Find possible names by using 'get_dem_names()'
 
@@ -42,9 +56,8 @@ def load_dem(dem: str, cache=True, data_home=None):
     url = f"{DEM_SOURCE}/{dem}.tif"
 
     if cache:
-        cache_path = os.path.join(get_save_location(data_home), f"{dem}.tif")
+        cache_path = os.path.join(get_save_location(), f"{dem}.tif")
 
-        # only download if not already downloaded
         if not os.path.exists(cache_path):
             urlretrieve(url, cache_path)
 
@@ -57,8 +70,8 @@ def load_dem(dem: str, cache=True, data_home=None):
     return dem
 
 
-def get_save_location(data_home=None):
-    """Genrates filepath to file saved in cache
+def get_save_location():
+    """Generates filepath to file saved in cache.
 
     Args:
         data_home (str, optional): name of directory in cache. Defaults to None
@@ -67,43 +80,21 @@ def get_save_location(data_home=None):
     Returns:
         str: filepath to file saved in cache.
     """
-    if data_home is None:
-        data_home = cache_dir("topotoolbox")
-
-    # turn ~ shorthand to full path
-    data_home = os.path.expanduser(data_home)
-
-    # create path if it dosnt exsist already
-    if not os.path.exists(data_home):
-        os.makedirs(data_home)
-
-    return data_home
-
-
-def cache_dir(appname=None):
-    """Generates filepath for cache directory.
-
-    Args:
-        appname (str, optional): Optional name for cache reposetory. Defaults to None.
-
-    Returns:
-        str: Path to cache directory.
-    """
     system = sys.platform
 
     if system == "win32":
         path = os.getenv('LOCALAPPDATA')
-        if appname:
-            path = os.path.join(path, appname)
+        path = os.path.join(path, "topotoolbox")
 
     elif system == 'darwin':
         path = os.path.expanduser('~/Library/Caches')
-        if appname:
-            path = os.path.join(path, appname)
+        path = os.path.join(path, "topotoolbox")
 
     else:
-        path = os.getenv(os.path.expanduser('~/.cache'))
-        if appname:
-            path = os.path.join(path, appname)
+        path = os.path.expanduser('~/.cache')
+        path = os.path.join(path, "topotoolbox")
+
+    if not os.path.exists(path):
+        os.makedirs(path)
 
     return path

--- a/src/topotoolbox/utils.py
+++ b/src/topotoolbox/utils.py
@@ -14,8 +14,8 @@ DEM_NAMES = ['kunashiri', 'perfectworld',
              'taalvolcano', 'taiwan', 'tibet', 'kedarnath']
 
 
-def read_tif(path: str):
-    """Generate a new GridObject from .tif file.
+def read_tif(path: str) -> GridObject:
+    """Generate a new GridObject from a .tif file.
 
     Args:
         path (str): path to .tif file.
@@ -26,27 +26,29 @@ def read_tif(path: str):
     return GridObject(path)
 
 
-def get_dem_names():
+def get_dem_names() -> list[str]:
     """Returns a list of provided example Digital Elevation Models (DEMs).
 
     Returns:
         list: A list of strings, where each string is the name of a DEM.
 
     Note:
-        If a file with all names is added to the 'wschwanghart/DEMs' repository, 
-        the DEM_NAMES list could be generated dynamically from that file. This would 
-        ensure the list remains up-to-date if the files ever change.
+        If a file with all names is added to the 'wschwanghart/DEMs' 
+        repository, the DEM_NAMES list could be generated dynamically from 
+        that file. This would ensure the list remains up-to-date if the 
+        files ever change.
     """
     return DEM_NAMES
 
 
-def load_dem(dem: str, cache=True):
+def load_dem(dem: str, cache=True) -> GridObject:
     """Downloads DEM from wschwanghart/DEMs reposetory. 
     Find possible names by using 'get_dem_names()'
 
     Args:
         dem (str): Name of dem about to be downloaded
-        cache (bool, optional): If true the dem will be cached. Defaults to True.
+        cache (bool, optional): If true the dem will be cached. 
+        Defaults to True.
         data_home (str, optional): optional name of cache. Defaults to None.
 
     Returns:
@@ -70,7 +72,7 @@ def load_dem(dem: str, cache=True):
     return dem
 
 
-def get_save_location():
+def get_save_location() -> str:
     """Generates filepath to file saved in cache.
 
     Args:

--- a/src/topotoolbox/utils.py
+++ b/src/topotoolbox/utils.py
@@ -46,15 +46,10 @@ def load_dem(dem: str, cache=True) -> GridObject:
         dem (str): Name of dem about to be downloaded
         cache (bool, optional): If true the dem will be cached. 
         Defaults to True.
-        data_home (str, optional): optional name of cache. Defaults to None.
 
     Returns:
         GridObject: A GridObject generated from the downloaded dem.
     """
-    if dem not in get_dem_names():
-        err = ("DEM has to be chosen from the list of available DEMs."
-               "Use 'get_dem_names()' to generate list of all available DEMs")
-        raise ValueError(err)
 
     url = f"{DEM_SOURCE}/{dem}.tif"
 


### PR DESCRIPTION
In this pull request, I added the following functions:

- `topotoolbox.load_dem()` enter DEM name as argument, it will download the tif if it isn't already cached.
- `topotoolbox.get_dem_names()` will return a list of all available tifs for `load_dem()`. if we add a .txt which contains all names to the repository which contains the tifs, we can implement it more dynamically. (right now it's just a list in the .py file)
- `topotoolbox.read_tif()` is a wrapper for creating a GridObject. Could be a cleaner way to create a GridObject inspired by pandas (pandas.read_csv creates a pandas.Dataframe).

Since the function `get_save_location()` in `utils.py` is not listed in `__all__` it's not automatically imported when using the package. This way it's "private" and not usable for the user by default.

I also fixed some line length issues in the mixin files for the GridObject. The maximum line length is 79 chars.