### PR TITLE
Add show and saving functions

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -6,7 +6,9 @@ API Documentation
    :recursive:
 
    topotoolbox.GridObject
+   topotoolbox.show
    topotoolbox.read_tif
+   topotoolbox.write_tif
    topotoolbox.load_dem
    topotoolbox.get_dem_names
    topotoolbox.get_cache_contents

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -2,6 +2,7 @@ Examples
 ========
 
 .. nbgallery::
+   /_temp/plotting.ipynb
    /_temp/test_genGrid
    /_temp/test_GridObject
    /_temp/test_load_dem

--- a/examples/plotting.ipynb
+++ b/examples/plotting.ipynb
@@ -1,0 +1,110 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Plotting DEMs\n",
+    "-------------\n",
+    "\n",
+    "This workflow will provide examples on how to plot your DEMs.\n",
+    "\n",
+    "Inbuild functions\n",
+    "=================\n",
+    "\n",
+    "There a two ways to plot your DEMs using the provided show functions. \n",
+    "- The class GridObject has the inbuilt GridObject.show(), which will plot the object using matplotlib. \n",
+    "- To plot multiple GridObjects, use topotoolbox.show(). This util function can take multiple GridObject as arguments."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import topotoolbox as topo"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dem1 = topo.load_dem(\"taiwan\")\n",
+    "dem1.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dem2 = topo.load_dem('perfectworld')\n",
+    "dem3 = topo.load_dem('kunashiri')\n",
+    "\n",
+    "# To increase resolution use the dpi argument. Default value is 100.\n",
+    "topo.show(dem1, dem2, dem3)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "External plotting\n",
+    "=================\n",
+    "\n",
+    "If you want to customize your plots, use the matplotlib library. A GridObject can be passed just like a np.ndarray when plotting."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, (ax1, ax2) = plt.subplots(1, 2, dpi=200)\n",
+    "ax1.imshow(dem1, cmap='terrain')\n",
+    "ax1.set_title(dem1.name)\n",
+    "\n",
+    "ax2.imshow(dem2, cmap='terrain')\n",
+    "ax2.set_title('my custom plot name')\n",
+    "\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/examples/saving_dem.ipynb
+++ b/examples/saving_dem.ipynb
@@ -1,0 +1,55 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import topotoolbox as topo"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dem = topo.load_dem(\"taiwan\")\n",
+    "dem.info()\n",
+    "dem.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "topo.show(dem, dem, dem)\n",
+    "# topo.write_tif(dem, \"test_file.tif\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/src/topotoolbox/grid_object.py
+++ b/src/topotoolbox/grid_object.py
@@ -4,6 +4,7 @@
 import copy
 
 import numpy as np
+import matplotlib.pyplot as plt
 
 # pylint: disable=import-error
 from ._grid import grid_fillsinks  # type: ignore
@@ -19,13 +20,21 @@ class GridObject():
     def __init__(self) -> None:
         """Initialize a GridObject instance.
         """
-
+        # path to tif file
         self.path = ''
+
+        # raster metadata
         self.z = np.empty(())
         self.rows = 0
         self.columns = 0
         self.shape = self.z.shape
+
         self.cellsize = 0
+
+        # georeference:
+        self.bounds = None
+        self.transform = None
+        self.crs = None
 
     def fillsinks(self):
         """Fill sinks in the digital elevation model (DEM).
@@ -102,12 +111,20 @@ class GridObject():
     def info(self):
         """Prints all variables of a GridObject.
         """
-        print("path: "+str(self.path))
-        print("rows: "+str(self.rows))
-        print("cols: "+str(self.columns))
-        print("cellsize: "+str(self.cellsize))
+        print(f"path: {self.path}")
+        print(f"rows: {self.rows}")
+        print(f"cols: {self.columns}")
+        print(f"cellsize: {self.cellsize}")
+        print(f"bounds: {self.bounds}")
+        print(f"transform: {self.transform}")
+        print(f"crs: {self.crs}")
+
+    def show(self):
+        plt.imshow(self, cmap='terrain')
+        plt.show()
 
     # 'Magic' functions:
+    # ------------------------------------------------------------------------
 
     def __eq__(self, other):
         dem = copy.deepcopy(self)
@@ -328,7 +345,7 @@ class GridObject():
             value = np.float32(value)
         except:
             raise TypeError(
-                value, " not can't be converted to float32.") from None
+                f"{value} can't be converted to float32.") from None
 
         self.z[index] = value
 

--- a/src/topotoolbox/grid_object.py
+++ b/src/topotoolbox/grid_object.py
@@ -20,8 +20,10 @@ class GridObject():
     def __init__(self) -> None:
         """Initialize a GridObject instance.
         """
-        # path to tif file
+        # path to file
         self.path = ''
+        # name of dem
+        self.name = ''
 
         # raster metadata
         self.z = np.empty(())
@@ -31,7 +33,7 @@ class GridObject():
 
         self.cellsize = 0
 
-        # georeference:
+        # georeference
         self.bounds = None
         self.transform = None
         self.crs = None
@@ -111,6 +113,7 @@ class GridObject():
     def info(self):
         """Prints all variables of a GridObject.
         """
+        print(f"name: {self.name}")
         print(f"path: {self.path}")
         print(f"rows: {self.rows}")
         print(f"cols: {self.columns}")
@@ -120,7 +123,13 @@ class GridObject():
         print(f"crs: {self.crs}")
 
     def show(self):
+        """
+        Display the GridObject instance as an image using Matplotlib.
+        """
         plt.imshow(self, cmap='terrain')
+        plt.title(self.name)
+        plt.colorbar()
+        plt.tight_layout()
         plt.show()
 
     # 'Magic' functions:

--- a/src/topotoolbox/utils.py
+++ b/src/topotoolbox/utils.py
@@ -8,14 +8,50 @@ from urllib.request import urlopen, urlretrieve
 
 import rasterio
 import numpy as np
+import matplotlib.pyplot as plt
 
 from .grid_object import GridObject
 
-__all__ = ["load_dem", "get_dem_names", "read_tif", "gen_random",
-           "gen_random_bool", "get_cache_contents", "clear_cache"]
+__all__ = ["load_dem", "get_dem_names", "read_tif", "gen_random", "write_tif",
+           "gen_random_bool", "get_cache_contents", "clear_cache", "show"]
 
 DEM_SOURCE = "https://raw.githubusercontent.com/TopoToolbox/DEMs/master"
 DEM_NAMES = f"{DEM_SOURCE}/dem_names.txt"
+
+
+def write_tif(dem: GridObject, path: str) -> None:
+
+    if not isinstance(dem, GridObject):
+        # TODO: -------------- error message ---------------------------------
+        err = ''
+        raise TypeError(err) from None
+
+    with rasterio.open(
+            fp=path,
+            mode='w',
+            count=1,
+            driver='GTiff',
+            height=dem.rows,
+            width=dem.columns,
+            dtype=np.float32,
+            crs=dem.crs,
+            transform=dem.transform
+    ) as dataset:
+        dataset.write(dem.z, 1)
+
+
+def show(*grid):
+    num_grids = len(grid)
+    fig, axes = plt.subplots(1, num_grids, figsize=(5*num_grids, 5))
+
+    for i, matrix in enumerate(grid):
+        ax = axes[i] if num_grids > 1 else axes
+        im = ax.imshow(matrix, cmap="terrain")
+        ax.set_title(f"DEM {i+1}")
+        fig.colorbar(im, ax=ax, orientation='vertical')
+
+    plt.tight_layout()
+    plt.show()
 
 
 def read_tif(path: str) -> GridObject:
@@ -44,11 +80,16 @@ def read_tif(path: str) -> GridObject:
             raise ValueError(err) from None
 
         grid.path = path
+
         grid.z = dataset.read(1).astype(np.float32)
         grid.rows = dataset.height
         grid.columns = dataset.width
         grid.shape = grid.z.shape
+
         grid.cellsize = dataset.res[0]
+        grid.bounds = dataset.bounds
+        grid.transform = dataset.transform
+        grid.crs = dataset.crs
 
     return grid
 
@@ -231,7 +272,7 @@ def clear_cache(filename: str = None) -> None:
     Parameters
     ----------
     filename : str, optional
-        Add a filename if only one specific file is to be deleted. 
+        Add a filename if only one specific file is to be deleted.
         Defaults to None.
     """
     path = get_save_location()


### PR DESCRIPTION
Changelog:
- Add show function to GridObject which plots using matplotlib
- Add show function to utils which is able to plot multiple GridObjects and change the resolution/dpi of the resulting plots
- Add geo-referencing information to GridObject
- Add to_tif function, which can save GridObject as a .tif file
- Add jupyter notebook example for the show functions
- Add new functions to documentation

closes #47 
closes #44 
closes #43
