### PR TITLE
Fix matrix passing to C/C++

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,10 +14,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,24 +4,12 @@ on:
   push:
     branches: ["matrix-passing-fix"]
 jobs:
-  build:
+  build-and-test:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-    steps:
-      - name: Checkout package
-        uses: actions/checkout@v4
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.10'
-      - name: Install package
-        run: python -m pip install .[opensimplex]
-        
-  test:
-    runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -29,7 +17,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.10'
+          python-version: ['3.9', '3.10', '3.11']
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,10 +20,11 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-          
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
+          pip install pytest
           pip install .[opensimplex]
 
       - name: Run tests

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,7 +2,7 @@ name: CI
 on:
   pull_request:    
   push:
-    branches: ["matrix-passing-fix"]
+    branches: ["main"]
 jobs:
   build-and-test:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,6 +10,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ['3.9', '3.10', '3.11']
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -17,8 +19,8 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: ['3.9', '3.10', '3.11']
-
+          python-version: ${{ matrix.python-version }}
+          
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,5 +19,7 @@ jobs:
           python-version: '3.10'
       - name: Install package
         run: python -m pip install .[opensimplex]
-      - name: Test package
-        run: python -c "import topotoolbox as topo; dem = topo.gen_random(); assert (dem.fillsinks() >= dem).z.all()"
+      - name: Run tests
+        run: |
+          pip install pytest
+          pytest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,23 @@ jobs:
           python-version: '3.10'
       - name: Install package
         run: python -m pip install .[opensimplex]
+        
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.10'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install .[opensimplex]
+
       - name: Run tests
         run: |
-          pip install pytest
-          pytest
+          python -m pytest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,7 +2,7 @@ name: CI
 on:
   pull_request:    
   push:
-    branches: ["main"]
+    branches: ["matrix-passing-fix"]
 jobs:
   build:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.9', '3.10', '3.11']
+        python-version: ['3.10', '3.11']
 
     steps:
       - name: Checkout repository

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ docs/_autosummary/*
 
 # ignore _temp
 docs/_temp
+
+# ignore pytest_cache
+.pytest_cache/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,13 +4,13 @@ project(${SKBUILD_PROJECT_NAME}
   VERSION ${SKBUILD_PROJECT_VERSION}
   LANGUAGES CXX)
 
-# Find TopoToolbox somewhere
+# include libtopotoolbox
 include(FetchContent)
 FetchContent_Declare(
   topotoolbox
   GIT_REPOSITORY https://github.com/TopoToolbox/libtopotoolbox.git
-  GIT_TAG main # In the future, we should track a specific tag/commit
-	       # and bump it as we release versions
+  # GIT_TAG main
+  GIT_TAG 2024-W27
 )
 FetchContent_MakeAvailable(topotoolbox)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "matplotlib",
     "rasterio"
 ]
-requires-python = ">=3.7"
+requires-python = ">=3.10"
 keywords = ["TopoToolbox"]
 classifiers = []
 

--- a/src/topotoolbox/grid_object.py
+++ b/src/topotoolbox/grid_object.py
@@ -66,7 +66,8 @@ class GridObject():
         raw : bool, optional
             If True, returns the raw output grid as np.ndarray. 
             Defaults to False.
-        output : list of str, optional
+        output : list of str,
+                flat_neighbors = 0 optional
             List of strings indicating desired output types. Possible values 
             are 'sills', 'flats'. Defaults to ['sills', 'flats'].
 
@@ -97,13 +98,13 @@ class GridObject():
         result = []
         if 'flats' in output:
             flats = copy.copy(self)
-            flats.z = np.zeros_like(flats.z)
+            flats.z = np.zeros_like(flats.z, order='F')
             flats.z = np.where((output_grid & 1) == 1, 1, flats.z)
             result.append(flats)
 
         if 'sills' in output:
             sills = copy.copy(self)
-            sills.z = np.zeros_like(sills.z)
+            sills.z = np.zeros_like(sills.z, order='F')
             sills.z = np.where((output_grid & 2) == 2, 1, sills.z)
             result.append(sills)
 

--- a/src/topotoolbox/grid_object.py
+++ b/src/topotoolbox/grid_object.py
@@ -22,11 +22,11 @@ class GridObject():
         """
         # path to file
         self.path = ''
-        # name of dem
+        # name of DEM
         self.name = ''
 
         # raster metadata
-        self.z = np.empty(())
+        self.z = np.empty((), order='F')
         self.rows = 0
         self.columns = 0
         self.shape = self.z.shape

--- a/src/topotoolbox/grid_object.py
+++ b/src/topotoolbox/grid_object.py
@@ -47,8 +47,7 @@ class GridObject():
             The filled DEM.
         """
 
-        dem = self.z.astype(np.float32)
-
+        dem = self.z.astype(np.float32, order='F')
         output = np.zeros_like(dem)
 
         grid_fillsinks(output, dem, self.rows, self.columns)
@@ -87,8 +86,8 @@ class GridObject():
         if output is None:
             output = ['sills', 'flats']
 
-        dem = self.z.astype(np.float32)
-        output_grid = np.zeros_like(dem).astype(np.int32)
+        dem = self.z.astype(np.float32, order='F')
+        output_grid = np.zeros_like(dem, dtype=np.int32)
 
         grid_identifyflats(output_grid, dem, self.rows, self.columns)
 
@@ -122,11 +121,16 @@ class GridObject():
         print(f"transform: {self.transform}")
         print(f"crs: {self.crs}")
 
-    def show(self):
+    def show(self, cmap='terrain'):
         """
         Display the GridObject instance as an image using Matplotlib.
+
+        Parameters
+        ----------
+        cmap : str, optional
+            Matplotlib colormap that will be used in the plot. 
         """
-        plt.imshow(self, cmap='terrain')
+        plt.imshow(self, cmap=cmap)
         plt.title(self.name)
         plt.colorbar()
         plt.tight_layout()

--- a/src/topotoolbox/utils.py
+++ b/src/topotoolbox/utils.py
@@ -59,7 +59,7 @@ def write_tif(dem: GridObject, path: str) -> None:
         dataset.write(dem.z, 1)
 
 
-def show(*grid: GridObject, dpi: int = 100):
+def show(*grid: GridObject, dpi: int = 100, cmap: str = 'terrain'):
     """
     Display one or more GridObject instances using Matplotlib.
 
@@ -70,6 +70,8 @@ def show(*grid: GridObject, dpi: int = 100):
         should have an attribute `name` and be suitable for use with `imshow`.
     dpi : int, optional
         The resolution of the plots in dots per inch. Default is 100.
+    cmap : str, optional
+        Matplotlib colormap that will be used in the plot. 
 
     Notes
     -----
@@ -89,7 +91,7 @@ def show(*grid: GridObject, dpi: int = 100):
     fig, axes = plt.subplots(1, num_grids, figsize=(5*num_grids, 5), dpi=dpi)
     for i, dem in enumerate(grid):
         ax = axes[i] if num_grids > 1 else axes
-        im = ax.imshow(dem, cmap="terrain")
+        im = ax.imshow(dem, cmap=cmap)
         ax.set_title(dem.name)
         fig.colorbar(im, ax=ax, orientation='vertical')
 
@@ -126,6 +128,7 @@ def read_tif(path: str) -> GridObject:
         grid.name = os.path.splitext(os.path.basename(grid.path))[0]
 
         grid.z = dataset.read(1).astype(np.float32)
+        # TODO: possible nrows, ncols mixup here?
         grid.rows = dataset.height
         grid.columns = dataset.width
         grid.shape = grid.z.shape

--- a/src/topotoolbox/utils.py
+++ b/src/topotoolbox/utils.py
@@ -128,7 +128,6 @@ def read_tif(path: str) -> GridObject:
         grid.name = os.path.splitext(os.path.basename(grid.path))[0]
 
         grid.z = dataset.read(1).astype(np.float32)
-        # TODO: possible nrows, ncols mixup here?
         grid.rows = dataset.height
         grid.columns = dataset.width
         grid.shape = grid.z.shape
@@ -142,7 +141,7 @@ def read_tif(path: str) -> GridObject:
 
 
 def gen_random(hillsize: int = 24, rows: int = 128, columns: int = 128,
-               cellsize: float = 10.0) -> 'GridObject':
+               cellsize: float = 10.0, seed: int = 3) -> 'GridObject':
     """Generate a GridObject instance that is generated with OpenSimplex noise.
 
     Parameters
@@ -155,6 +154,8 @@ def gen_random(hillsize: int = 24, rows: int = 128, columns: int = 128,
         Number of columns. Defaults to 128.
     cellsize : float, optional
         Size of each cell in the grid. Defaults to 10.0.
+    seed : int, optional
+        Seed for the terrain generation. Defaults to 3
 
     Raises
     ------
@@ -174,7 +175,9 @@ def gen_random(hillsize: int = 24, rows: int = 128, columns: int = 128,
                "box[opensimplex]\" or \"pip install .[opensimplex]\"")
         raise ImportError(err) from None
 
-    noise_array = np.empty((rows, columns), dtype=np.float32)
+    noise_array = np.empty((rows, columns), dtype=np.float32, order='F')
+
+    simplex.seed(seed)
     for y in range(0, rows):
         for x in range(0, columns):
             value = simplex.noise4(x / hillsize, y / hillsize, 0.0, 0.0)
@@ -183,7 +186,6 @@ def gen_random(hillsize: int = 24, rows: int = 128, columns: int = 128,
 
     grid = GridObject()
 
-    grid.path = ''
     grid.z = noise_array
     grid.rows = rows
     grid.columns = columns

--- a/src/topotoolbox/utils.py
+++ b/src/topotoolbox/utils.py
@@ -127,7 +127,7 @@ def read_tif(path: str) -> GridObject:
         grid.path = path
         grid.name = os.path.splitext(os.path.basename(grid.path))[0]
 
-        grid.z = dataset.read(1).astype(np.float32)
+        grid.z = dataset.read(1).astype(np.float32, order='F')
         grid.rows = dataset.height
         grid.columns = dataset.width
         grid.shape = grid.z.shape

--- a/tests/test_grid_object.py
+++ b/tests/test_grid_object.py
@@ -1,0 +1,58 @@
+import numpy as np
+import pytest
+
+import topotoolbox.grid_object as topo
+
+
+@pytest.fixture
+def squareGridObject():
+    grid = topo.GridObject()
+    grid.z = np.array([
+        [1, 1, 1, 1, 1],
+        [1, 0, 0, 0, 1],
+        [1, 0, 1, 0, 1],
+        [1, 0, 0, 0, 1],
+        [1, 1, 1, 1, 1]
+    ])
+    grid.rows, grid.columns = grid.z.shape
+    grid.shape = grid.z.shape
+    return grid
+
+
+@pytest.fixture
+def tallGridObject():
+    grid = topo.GridObject()
+    grid.z = np.array([
+        [1, 1, 1],
+        [1, 0, 0],
+        [1, 0, 1],
+        [1, 0, 0],
+        [1, 1, 1],
+        [1, 0, 1],
+        [1, 0, 1],
+        [1, 1, 1]
+    ])
+    grid.rows, grid.columns = grid.z.shape
+    grid.shape = grid.z.shape
+    return grid
+
+
+@pytest.fixture
+def wideGridObject():
+    grid = topo.GridObject()
+    grid.z = np.array([
+        [1, 1, 1, 1, 1, 1, 1],
+        [1, 0, 0, 0, 1, 1, 0],
+        [1, 0, 1, 0, 1, 0, 1],
+    ])
+    grid.rows, grid.columns = grid.z.shape
+    grid.shape = grid.z.shape
+    return grid
+
+
+def test_fillsinks():
+    assert True
+
+
+def test_identifyflats():
+    pass

--- a/tests/test_grid_object.py
+++ b/tests/test_grid_object.py
@@ -21,6 +21,7 @@ def tall_dem():
 
 def test_fillsinks(square_dem, wide_dem, tall_dem):
     for grid in [square_dem, wide_dem, tall_dem]:
+        # since grid is a fixture, it has to be assigned first
         dem = grid
         filled_dem = dem.fillsinks()
 

--- a/tests/test_grid_object.py
+++ b/tests/test_grid_object.py
@@ -21,7 +21,7 @@ def tall_dem():
 
 def test_fillsinks(square_dem, wide_dem, tall_dem):
     for grid in [square_dem, wide_dem, tall_dem]:
-        # since grid is a fixture, it has to be assigned first
+        # since grid is a fixture, it has to be assigned/called first
         dem = grid
         filled_dem = dem.fillsinks()
 
@@ -57,5 +57,29 @@ def test_fillsinks(square_dem, wide_dem, tall_dem):
                 assert sink < 8
 
 
-def test_identifyflats():
-    pass
+def test_identifyflats(square_dem, wide_dem, tall_dem):
+    for dem in [square_dem, wide_dem, tall_dem]:
+        sills, flats = dem.identifyflats()
+
+        for i in range(dem.shape[0]):
+            for j in range(dem.shape[1]):
+
+                for i_offset, j_offset in [
+                        (-1, -1),
+                        (-1, 0),
+                        (-1, 1),
+                        (0, -1),
+                        (0, 1),
+                        (1, -1),
+                        (1, 0),
+                        (1, 1)]:
+
+                    i_neighbor = i + i_offset
+                    j_neighbor = j + j_offset
+
+                    if (i_neighbor < 0 or i_neighbor >= dem.z.shape[0]
+                            or j_neighbor < 0 or j_neighbor >= dem.z.shape[1]):
+                        continue
+
+                    if flats[i_neighbor, j_neighbor] < flats[i, j]:
+                        assert flats[i, j] == 1.0

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,2 @@
+import pytest
+import topotoolbox.utils


### PR DESCRIPTION
In this pull request, I have fixed the problem of row-major/column-major when passing the matrix. Much like in @bgailleton  's solution, I'm using the `order='F'` argument.
```python
grid.z = dataset.read(1).astype(np.float32, order='F')
```
Initially, I experimented with transposing the matrix, but just using `my_matrix.T` does not solve the row-major/column-major problem. I don't think we need to rotate our matrices in order for the functions to work, right?
If not, this fixes #50 .

Other than that, I added a few basic tests and updated the ci.yaml accordingly. 
closes #41 

The oldest supported version is python 3.10 right now. We should figure out if we also want to make it compatible with older versions. 