### PR TITLE
Bump versions of actions/checkout and actions/setup-python

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,10 +14,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 


### PR DESCRIPTION
I noticed GitHub Actions was giving us some deprecation warnings. I've moved to actions/checkout@v4 and actions/setup-python@v5, which seem to be the current versions of these actions and which seem to work without changing anything on our end.