### PR TITLE
Fix the build time version of numpy to 2.0.0 or greater

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,11 @@
 [build-system]
-requires = ["scikit-build-core","pybind11"]
 build-backend = "scikit_build_core.build"
+requires = [
+    "scikit-build-core",
+    "pybind11",
+    "numpy>=2.0.0"
+]
+
 
 [project]
 name = "topotoolbox"


### PR DESCRIPTION
NumPy 2 can build binaries that are compatible with the NumPy 1 C ABI, but not vice versa. As long as we build with NumPy 2, users should be able to use older versions of NumPy without problems.