### PR TITLE
Remove version specifications from pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,16 +20,16 @@ description = "Python interface to TopoToolbox."
 readme = "README.md"
 license = { file = "LICENSE" }
 dependencies = [
-    "numpy==2.1.3",
-    "matplotlib==3.9.2",
-    "rasterio==1.4.2"
+    "numpy",
+    "matplotlib",
+    "rasterio"
 ]
 requires-python = ">=3.10"
 keywords = ["TopoToolbox"]
 classifiers = []
 
 [project.optional-dependencies]
-opensimplex = ["opensimplex==0.4.5.1"]
+opensimplex = ["opensimplex"]
 
 [project.urls]
 Homepage = "https://topotoolbox.github.io"


### PR DESCRIPTION
I changed my mind about specifying versions in pyproject.toml (#68), but I wanted to go ahead and merge that one. I think having requirements.txt for developers and the automated testing infrastructure to have a consistent environment is all right, though we might need to think about how we decide when to bump those versions. We shouldn't constrain users of the library to also have a particular version of the dependencies unless it is necessary for our topotoolbox functionality that a certain dependency version be available.