### PR TITLE
Number nodes of StreamObject correctly

### DIFF
--- a/tests/test_stream_object.py
+++ b/tests/test_stream_object.py
@@ -21,9 +21,9 @@ def tall_dem():
 
 def test_init(tall_dem, wide_dem):
     assert (wide_dem.target.size == wide_dem.source.size ==
-            wide_dem.direction.size == wide_dem.stream.size)
+            wide_dem.direction.size)
     assert (tall_dem.target.size == tall_dem.source.size ==
-            tall_dem.direction.size == tall_dem.stream.size)
+            tall_dem.direction.size)
 
     # Ensure that no index in stream exceeds the max possible index in the grid
     assert np.max(wide_dem.stream) <= wide_dem.shape[0] * wide_dem.shape[1]


### PR DESCRIPTION
@Teschl: It turns out I was a little confused about what the `StreamObject` arrays needed to look like. This should make everything work properly, but it may not be the best way to do it. Let me know if you see anything that could be improved

--

If there are n pixels within the stream network, as defined by the `stream_pixels` or `threshold` arrays, then `self.stream`, which is equivalent to `STREAMobj.IXgrid` in MATLAB, should be an array of n elements pointing to the linear indices of the pixels within the stream network. This is a node attribute list, because it stores one piece of information per node. I think this was correct in the last iteration.

However, `self.source` (`STREAMobj.ix`) and
`self.target` (`STREAMobj.ixc`) should be arrays of indices into the node attribute lists. They should range from 0 up to n. There are probably less than n elements of these arrays because they are edge attribute lists, and we don't include edges in the stream network for sinks or outlets, which are labeled with a target of -1 in the FlowObject.

This requires some complicated manipulations to get the right indices in the right order, but I am fairly confident this matches the MATLAB implementation with one exception. MATLAB TopoToolbox preprocesses the `stream_pixels` array by ensuring that target pixels that are in the stream network with corresponding source pixels also in the stream network are set in the `stream_pixels` array. I don't understand this part, and I have trouble seeing what situation would require this preprocessing. If we can find a concrete example where this preprocessing is necessary for correct results, we should add a test and a preprocessing step.

The test has been updated because the edge attribute lists are not necessarily the same size as the node attribute lists.