### PR TITLE
Add a release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,71 @@
+name: Create and upload wheels and source distribution
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  make_sdist:
+    name: Make SDist
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+
+      - name: Install build
+        run: python -m pip install build
+
+      - name: Build SDist
+        run: python -m build --sdist
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: cibw-sdist
+          path: dist/*.tar.gz
+  build_wheels:
+    name: Wheel on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest, macos-13]
+        cibw_arch: ["native"]
+        cibw_build: ["cp310-* cp311-* cp312-*"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+
+      - name: Install cibuildwheel
+        run: python -m pip install cibuildwheel==2.21.3
+
+      - name: Build wheels
+        run: python -m cibuildwheel --output-dir wheelhouse
+        env:
+          CIBW_ARCHS: ${{ matrix.cibw_arch }}
+          CIBW_BUILD: ${{ matrix.cibw_build }}
+          CIBW_SKIP: "*musllinux*"
+          CIBW_TEST_REQUIRES: pytest
+          CIBW_TEST_COMMAND: pytest {package}/tests
+          CIBW_TEST_EXTRAS: opensimplex
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}
+          path: ./wheelhouse/*.whl
+  upload_assets:
+    name: Upload release assets
+    needs: [build_wheels, make_sdist]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: cibw-*
+          path: dist
+          merge-multiple: true
+      - name: Upload assets to release
+        run: gh release upload --repo $GITHUB_REPOSITORY $TAG dist/*
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.event.release.tag_name }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,8 @@ project(${SKBUILD_PROJECT_NAME}
   VERSION ${SKBUILD_PROJECT_VERSION}
   LANGUAGES CXX)
 
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
 # include libtopotoolbox
 include(FetchContent)
 FetchContent_Declare(


### PR DESCRIPTION
This moves towards a solution for #67.

This workflow uses cibuildwheel to build binary wheels of pytopotoolbox on various architectures. When a release is made it will build and test all of these wheels and upload them as assets to the release.

It also sets the CMAKE_POSITION_INDEPENDENT_CODE flag because it seems like we need position independent code in our static libtopotoolbox library to link it successfully on certain platforms.

My plan is to add this workflow, make a release to ensure that everything works as expected, and then add a step to upload to PyPI. I have already implemented and tested that step, but I want to make sure that everything works here before we start uploading.

