### PR TITLE
Set version number to 0.0.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ requires = [
 
 [project]
 name = "topotoolbox"
-version = "3.0.1"
+version = "0.0.1"
 authors = [
     {name="Wolfgang Schwanghart", email="w.schwanghart@geo.uni-potsdam.de"},
     {name="Dirk Scherler", email="scherler@fz-potsdam.de"},


### PR DESCRIPTION
To avoid committing to semantic versioning at this point, we will start making releases with major number 0. The 0.0.x releases will be used to test our release process and CI infrastructure.

Until major version 1 is released, pytopotoolbox should be considered unstable and subject to change.