### PR TITLE
Add step to upload to test.pypi.org

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,3 +69,24 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ github.event.release.tag_name }}
+  upload-testpypi:
+    name: Upload release assets to test.pypi.org
+    needs: [build_wheels, make_sdist]
+    runs-on: ubuntu-latest
+    environment: testpypi
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: cibw-*
+          path: dist
+          merge-multiple: true
+      - name: Setup python
+        uses: actions/setup-python@v5
+      - name: Install twine
+        run: python -m pip install twine
+      - name: Upload release with twine
+        run: python -m twine upload --verbose dist/*
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          TWINE_REPOSITORY: testpypi


### PR DESCRIPTION
This uses twine to upload alongside an API token that is provided as a secret in the testpypi environment.