### PR TITLE
Switch from test.pypi.org to the main PyPI repository

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,24 +69,20 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ github.event.release.tag_name }}
-  upload-testpypi:
-    name: Upload release assets to test.pypi.org
+  upload-pypi:
+    name: Upload release assets to PyPI
     needs: [build_wheels, make_sdist]
     runs-on: ubuntu-latest
-    environment: testpypi
+    environment: pypi
+    permissions:
+      id-token: write
     steps:
       - uses: actions/download-artifact@v4
         with:
           pattern: cibw-*
           path: dist
           merge-multiple: true
-      - name: Setup python
-        uses: actions/setup-python@v5
-      - name: Install twine
-        run: python -m pip install twine
-      - name: Upload release with twine
-        run: python -m twine upload --verbose dist/*
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.TEST_PYPI_API_TOKEN }}
-          TWINE_REPOSITORY: testpypi
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          verbose: true


### PR DESCRIPTION
This attempts to use the gh-action-pypi-publish action to publish to PyPI instead of twine. It also uses the Trusted Publishing workflow to publish without an API token.