### PR TITLE
Restore NaNs in the original DEM after filling sinks

### DIFF
--- a/src/topotoolbox/flow_object.py
+++ b/src/topotoolbox/flow_object.py
@@ -61,6 +61,7 @@ class FlowObject():
         _grid.fillsinks(filled_dem, dem, bc, dims)
 
         if restore_nans:
+            dem[nans] = np.nan
             filled_dem[nans] = np.nan
 
         flats = np.zeros_like(dem, dtype=np.int32, order='F')

--- a/src/topotoolbox/grid_object.py
+++ b/src/topotoolbox/grid_object.py
@@ -83,6 +83,7 @@ class GridObject():
         _grid.fillsinks(output, dem, bc, self.shape)
 
         if restore_nans:
+            dem[nans] = np.nan
             output[nans] = np.nan
 
         result = copy.copy(self)


### PR DESCRIPTION
This ensures that the original DEM is not changed after calling `fillsinks`. This is not a problem in `GridObject.fillsinks`, because we make a copy of the DEM with the `astype` call while no copy is made in `FlowObject`. We probably should not make that copy if we can avoid it, though, so this change handles things correctly in both cases.