### PR TITLE
Add tests to ensure DEM is left unchanged by fillsinks

### DIFF
--- a/tests/test_flow_object.py
+++ b/tests/test_flow_object.py
@@ -1,3 +1,17 @@
 import pytest
 
+import numpy as np
 import topotoolbox as topo
+
+@pytest.fixture
+def wide_dem():
+    return topo.gen_random(rows=64, columns=128, seed=12)
+
+def test_flowobject(wide_dem):
+    dem = wide_dem
+    original_dem = dem.z.copy()
+    fd = topo.FlowObject(dem);
+
+    # Ensure that FlowObject does not modify the original DEM
+    assert np.all(dem.z == original_dem)
+

--- a/tests/test_grid_object.py
+++ b/tests/test_grid_object.py
@@ -24,7 +24,11 @@ def test_fillsinks(square_dem, wide_dem, tall_dem):
     for grid in [square_dem, wide_dem, tall_dem]:
         # since grid is a fixture, it has to be assigned/called first
         dem = grid
+        original_dem = dem.z.copy()
         filled_dem = dem.fillsinks()
+
+        # Ensure that DEM has not been modified by fillsinks
+        assert np.all(original_dem == dem.z)
 
         # Loop over all cells of the DEM
         for i in range(dem.shape[0]):


### PR DESCRIPTION
These tests complement the bugfix in #88.

They check after fillsinks is run that the DEM is identical to a saved copy of the original. Since fillsinks is run directly from the _grid module in FlowObject, the FlowObject test is added.