### PR TITLE
Make shape, rows and columns properties of GridObject

### DIFF
--- a/src/topotoolbox/flow_object.py
+++ b/src/topotoolbox/flow_object.py
@@ -146,7 +146,6 @@ class FlowObject():
         result.name = self.name
 
         result.z = acc
-        result.shape = self.shape
         result.cellsize = self.cellsize
 
         result.bounds = self.bounds

--- a/src/topotoolbox/grid_object.py
+++ b/src/topotoolbox/grid_object.py
@@ -30,9 +30,6 @@ class GridObject():
 
         # raster metadata
         self.z = np.empty((), order='F', dtype=np.float32)
-        self.rows = 0
-        self.columns = 0
-        self.shape = self.z.shape
 
         self.cellsize = 0.0  # in meters if crs.is_projected == True
 
@@ -40,6 +37,24 @@ class GridObject():
         self.bounds = None
         self.transform = None
         self.crs = None
+
+    @property
+    def shape(self):
+        """Tuple of grid dimensions
+        """
+        return self.z.shape
+
+    @property
+    def rows(self):
+        """The size of the first dimension of the grid
+        """
+        return self.z.shape[0]
+
+    @property
+    def columns(self):
+        """The size of the second dimension of the grid
+        """
+        return self.z.shape[1]
 
     def reproject(self,
                   crs: 'CRS',
@@ -86,10 +101,6 @@ class GridObject():
         # Get cellsize from transform in case we did not specify one
         if dst.transform is not None:
             dst.cellsize = abs(dst.transform[0])
-
-        dst.shape = dst.z.shape
-        dst.rows = dst.shape[0]
-        dst.columns = dst.shape[1]
 
         return dst
 

--- a/src/topotoolbox/utils.py
+++ b/src/topotoolbox/utils.py
@@ -130,9 +130,6 @@ def read_tif(path: str) -> GridObject:
         grid.name = os.path.splitext(os.path.basename(grid.path))[0]
 
         grid.z = dataset.read(1).astype(np.float32, order='F')
-        grid.rows = dataset.height
-        grid.columns = dataset.width
-        grid.shape = grid.z.shape
 
         grid.cellsize = dataset.res[0]
         grid.bounds = dataset.bounds
@@ -192,9 +189,6 @@ def gen_random(hillsize: int = 24, rows: int = 128, columns: int = 128,
     grid = GridObject()
 
     grid.z = noise_array
-    grid.rows = rows
-    grid.columns = columns
-    grid.shape = grid.z.shape
     grid.cellsize = cellsize
     grid.name = name
     return grid
@@ -230,9 +224,6 @@ def gen_random_bool(
 
     grid.path = ''
     grid.z = bool_array
-    grid.rows = rows
-    grid.columns = columns
-    grid.shape = grid.z.shape
     grid.cellsize = cellsize
     grid.name = name
 

--- a/tests/test_flow_object.py
+++ b/tests/test_flow_object.py
@@ -12,6 +12,9 @@ def test_flowobject(wide_dem):
     original_dem = dem.z.copy()
     fd = topo.FlowObject(dem);
 
+    # Run flow_accumulation at least once during the tests
+    acc = fd.flow_accumulation();
+
     # Ensure that FlowObject does not modify the original DEM
     assert np.all(dem.z == original_dem)
 


### PR DESCRIPTION
See the discussion in #90.

This ensures that these attributes remain synchronized with the underlying Numpy array that stores the data, but should not change the API of the object. It will break code that directly sets these attributes. I believe I have found and corrected all of those in the package.