### PR TITLE
Fix links to CONTRIBUTING.md in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ run into problems with installation, please open an
 
 ## Contributing
 
-If you would like to contribute to pytopotoolbox, check out the [Contribution Guidelines](./CONTRIBUTING.md).
+If you would like to contribute to pytopotoolbox, check out the [Contribution Guidelines](./docs/CONTRIBUTING.md).
 
 ## License
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -33,6 +33,8 @@ If you have a patch or new feature that you would like to contribute, please sub
 4. Ensure the test suite passes.
 5. Make sure your code lints.
 
+Check the [developer documentation](dev.rst) for more details about setting up your development environment and running the tests.
+
 ### Code Style
 
 Please follow the [PEP 8](https://pep8.org/) style guide for Python code. Make sure your code passes the linting tests (`pylint --rcfile=pyproject.toml src/topotoolbox/`, `mypy --ignore-missing-imports src/topotoolbox`) and the pytests (`python -m pytest`). Also add tests for new content you want to contribute.

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -15,15 +15,13 @@ AUTOSUMMARYDIR = _autosummary
 # Put it first so that "make" without argument is like "make help".
 help:
 	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
- 
+
 .PHONY: help Makefile
 
 # Target to build HTML documentation, including copying/removing examples
 html: 
 	@echo "Copying examples directory..."
 	@cp -r $(EXAMPLEDIR) $(TEMPDIR)
-	@echo "Copying CONTRIBUTING.md file..."
-	@cp -r ../CONTRIBUTING.md $(TEMPDIR)/CONTRIBUTING.md
 	@$(SPHINXBUILD) -M html "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 	@echo "Removing _temp directory..."
 	@rm -rf $(TEMPDIR)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,6 +13,7 @@ extensions = [
     'sphinx.ext.viewcode',
     'sphinx.ext.todo',
     'nbsphinx',
+    'myst_parser'
 ]
 
 project = 'TopoToolbox'

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -28,7 +28,7 @@ For further documentation regarding the functionality of this package, check out
 Contributing
 ------------
 
-If you would like to contribute to pytopotoolbox, refer to the :doc:`_temp/CONTRIBUTING`.
+If you would like to contribute to pytopotoolbox, refer to the :doc:`CONTRIBUTING`.
 
 .. toctree::
    :maxdepth: 1
@@ -37,7 +37,7 @@ If you would like to contribute to pytopotoolbox, refer to the :doc:`_temp/CONTR
    Tutorial <tutorial>
    Examples <examples>
    API <api>
-   Contributing <_temp/CONTRIBUTING>
+   Contribution Guidelines <CONTRIBUTING>
    Developer Documentation <dev>
 
 Indices and Tables

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,3 +2,4 @@ Sphinx==7.3.7
 sphinx-book-theme==1.1.2
 nbsphinx==0.9.4
 notebook==7.0.5
+myst-parser==3.0.1


### PR DESCRIPTION
The CONTRIBUTING.md was not being picked up because we didn't have `myst_parser` installed in our docs environment. I added `myst_parser` to `docs/conf.py` and `docs/requirements.txt`, and I moved CONTRIBUTING.md to the docs folder for ease of access. The link on the README has also been updated.