### PR TITLE
Add repository button to the docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -36,6 +36,11 @@ html_context = {
     "default_mode": "light",
 }
 
+html_theme_options = {
+    "repository_url": "https://github.com/TopoToolbox/pytopotoolbox",
+    "use_repository_button": True,
+}
+
 # -- Options for nbsphinx ----------------------------------------------------
 
 nbsphinx_allow_errors = True


### PR DESCRIPTION
I always find it useful to be able to jump directly to the GitHub repository from a documentation page.