### PR TITLE
Add wrapping guide to docs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -28,7 +28,7 @@ For further documentation regarding the functionality of this package, check out
 Contributing
 ------------
 
-If you would like to contribute to pytopotoolbox, refer to the :doc:`CONTRIBUTING`.
+If you would like to contribute to pytopotoolbox, refer to the :doc:`CONTRIBUTING` page. To get a better understanding of how we wrap functions for use in python, the :doc:`wrapping` page will help.
 
 .. toctree::
    :maxdepth: 1
@@ -39,6 +39,7 @@ If you would like to contribute to pytopotoolbox, refer to the :doc:`CONTRIBUTIN
    API <api>
    Contribution Guidelines <CONTRIBUTING>
    Developer Documentation <dev>
+   Wrapping Guide <wrapping>
 
 Indices and Tables
 ------------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -39,7 +39,7 @@ If you would like to contribute to pytopotoolbox, refer to the :doc:`CONTRIBUTIN
    API <api>
    Contribution Guidelines <CONTRIBUTING>
    Developer Documentation <dev>
-   Wrapping Guide <wrapping>
+   Wrapping LibTopoToolbox <wrapping>
 
 Indices and Tables
 ------------------

--- a/docs/wrapping.ipynb
+++ b/docs/wrapping.ipynb
@@ -1,0 +1,230 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# How to wrap `libtopotoolbox` functions with the `pytopotoolbox`\n",
+    "\n",
+    "## What needs to be done to add a new function\n",
+    "\n",
+    "You will need to modify content in the following directories and files:\n",
+    "\n",
+    "1. **src/topotoolbox/** [Refer to the section on wrapping pybind11 functions.](#wrapping-pybind11-functions)\n",
+    "\n",
+    "2. **src/topotoolbox/__init__.py** If you added a new file for a new class, you will need to add it here so it will be automatically imported when importing `topotoolbox`.\n",
+    "\n",
+    "3. **src/lib/** [Refer to the section on wrapping libtopotoolbox.](#creating-a-wrapper-for-libtopotoolbox-functions-using-pybind11)\n",
+    "\n",
+    "4. **CMakeLists.txt** If you added a new class, you will need to add a link using `target_link_libraries()`, `pybind_add_module()`, and the `install` section `install()`.\n",
+    "\n",
+    "5. **docs/api.rst** To include your function in the API documentation, add it here. Since we are using recursive autosummary, if your function is part of a class, it will automatically be added if the class is added to this file. If your function is not part of a class, you will need to add it manually.\n",
+    "\n",
+    "6. **tests/** Include tests for your function here.\n",
+    "\n",
+    "7. **examples/** If you want to provide an example as documentation for your function, create a new Jupyter notebook here. You can fill the file however you see fit, but make sure to include a section title for the file by making the first line your title and underlining it with `====`.\n",
+    "\n",
+    "8. **docs/examples.rst** If you added a new example, include it in the example gallery by adding a new line: `/_temp/name_of_your_example`\n",
+    "\n",
+    "9. **docs/conf.py** If you added a new example, you can also add a thumbnail for it here under the section `nbsphinx_thumbnails`.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Creating a wrapper for libtopotoolbox functions using pybind11\n",
+    "\n",
+    "We create a separate file for all wrappers of one class. The `src/lib/grip.cpp` will contain all wrappers for the GridObject class for example. Each file has to include the following code:\n",
+    "\n",
+    "```cpp\n",
+    "extern \"C\" {\n",
+    "    #include <topotoolbox.h>\n",
+    "}\n",
+    "\n",
+    "#include <pybind11/pybind11.h>\n",
+    "#include <pybind11/numpy.h>\n",
+    "\n",
+    "namespace py = pybind11;\n",
+    "```\n",
+    "\n",
+    "Create a wrapper by creating a new function, we name them void wrap_func_name() to differentiate them from the libtopotoolbox functions. In this function you create pointers for your arrays and pass them to the function you are wrapping void func_name(). We are always editing our data in place, to all function return void.\n",
+    "\n",
+    "```cpp\n",
+    "void wrap_func_name(py::array_t<float> dem, std::tuple<ptrdiff_t,ptrdiff_t> dims){\n",
+    "    float *dem_ptr = output.mutable_data();\n",
+    "    std::array<ptrdiff_t, 2> dims_array = {std::get<0>(dims), std::get<1>(dims)};\n",
+    "    ptrdiff_t *dims_ptr = dims_array.data();\n",
+    "    func_name(dem_ptr, dims_ptr);\n",
+    "}\n",
+    "```\n",
+    "\n",
+    "At the end of the file we will include the function to the Pybind11 module. The module will be named after the class it's used for. For the `grid.cpp` file the module is named `_grid`.\n",
+    "\n",
+    "```cpp\n",
+    "PYBIND11_MODULE(_module_name_, m) {\n",
+    "    m.def(\"function_name\", &wrap_function_name);\n",
+    "}\n",
+    "```\n",
+    "\n",
+    "When the topotoolbox package is beeing build these modules will be compiled and made available for the python wrappers."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Wrapping pybind11 functions\n",
+    "\n",
+    "Since the the pybind11 functions will only be available during the build process we always disable pylint errors when importing them into our python files. We do this so the code passes the pylint test we run in our .github/workflows and so that your IDE doesn't yell at you.\n",
+    "\n",
+    "```python\n",
+    "# pylint: disable=no-name-in-module\n",
+    "from . import _module_name  # type: ignore\n",
+    "```\n",
+    "\n",
+    "When creating your python function you call the pybind11 wrapper like so:\n",
+    "\n",
+    "```python\n",
+    "_module_name.function_name()\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## What order arrays should be in\n",
+    "\n",
+    "Because Matlab is using arrays in column major order, the libtopotoolbox is using them as well. While thats not forced for new functions anymore, the shape (dims) we pass along with our matrix has to match the matrix.\n",
+    "\n",
+    "The following example will showcase what this means in practice."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "\n",
+    "# creating the same array, once in C and once in F order\n",
+    "array_c = np.array([[1,2,3],[4,5,6],[7,8,9],[10,11,12]], order='C')\n",
+    "array_f = np.array([[1,2,3],[4,5,6],[7,8,9],[10,11,12]], order='F')\n",
+    "dims = array_f.shape\n",
+    "\n",
+    "print(f\"Both arrays will look like this when plotting at them:\\n{array_c}\")\n",
+    "\n",
+    "array_c = array_c.flatten(order='C')\n",
+    "array_f = array_f.flatten(order='F')\n",
+    "print(\"\\nBut when the arrays are passed to the C function, they will be\\n\"\n",
+    "      \"flattened into on dimension like this:\"\n",
+    "      f\"\\nC order: {array_c}\\nF order: {array_f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As you can see, the Column major order (F), will result in each column being listed after one another instead of each row being listed after another (C).\n",
+    "\n",
+    "The first element of dims[2] (generated from the np.ndarray.shape) should be the size of the dimension that changes fastest as you scan through memory, e.g. rows for column-major/'F' order and cols for row-major/'C' order.\n",
+    "\n",
+    "In our example for F order you can see that 1, 4 and 7 are next to each other in memory. They are all in different rows. Therefor rows change faster than cols so the value denoting how many rows there are should be first value (dims[0])."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(dims)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In our example there are 4 rows and 3 columns. Since the rows are first in dims we should pass this array to the C/C++ code in F order.\n",
+    "\n",
+    "When looping trough the array we try to access the elements after another that are actually located next to each other in memory. Therefor the outer for loop should loop over dims[1] the inner over dims[0]."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for j in range(dims[1]):\n",
+    "    for i in range(dims[0]):\n",
+    "        location = j * dims[0] + i\n",
+    "        print(array_f[location], end=', ')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To access neighboring cells in the same col we just need to add or subtract 1 from the index. For neighboring cells in same row we need to either add or subtract the length of one row (dims[0]) from the index. \n",
+    "\n",
+    "In our example the neighbors of 5 in memory are 2 and 8. The neigbors on the same row are 4 and 6."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f\"array[5] = {array_f[5]}\")\n",
+    "print(f\"above = {array_f[5-1]}\")\n",
+    "print(f\"below = {array_f[5+1]}\")\n",
+    "print(f\"left = {array_f[5-dims[0]]}\")\n",
+    "print(f\"right = {array_f[5+dims[0]]}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Alternative way to loop through the array:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for index in range(dims[0] * dims[1]):\n",
+    "    col = index // dims[0] \n",
+    "    row = index % dims[0]  \n",
+    "    print(f\"i: {index}, row: {row}, col: {col}, array[i] = {array_f[index]}\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/docs/wrapping.ipynb
+++ b/docs/wrapping.ipynb
@@ -24,7 +24,7 @@
     "\n",
     "7. **examples/** If you want to provide an example as documentation for your function, create a new Jupyter notebook here. You can fill the file however you see fit, but make sure to include a section title for the file by making the first line your title and underlining it with `====`.\n",
     "\n",
-    "8. **docs/examples.rst** If you added a new example, include it in the example gallery by adding a new line: `/_temp/name_of_your_example`\n",
+    "8. **docs/examples.rst** If you added a new example, include it in the example gallery by adding a new line: `/examples/name_of_your_example`\n",
     "\n",
     "9. **docs/conf.py** If you added a new example, you can also add a thumbnail for it here under the section `nbsphinx_thumbnails`.\n"
    ]
@@ -208,7 +208,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },

--- a/docs/wrapping.ipynb
+++ b/docs/wrapping.ipynb
@@ -16,7 +16,7 @@
     "\n",
     "3. **src/lib/** [Refer to the section on wrapping libtopotoolbox.](#creating-a-wrapper-for-libtopotoolbox-functions-using-pybind11)\n",
     "\n",
-    "4. **CMakeLists.txt** If you added a new class, you will need to add a link using `target_link_libraries()`, `pybind_add_module()`, and the `install` section `install()`.\n",
+    "4. **CMakeLists.txt** If you added a new class, you will need to add a link using `target_link_libraries()`, `pybind_add_module()`, and the install section `install()`.\n",
     "\n",
     "5. **docs/api.rst** To include your function in the API documentation, add it here. Since we are using recursive autosummary, if your function is part of a class, it will automatically be added if the class is added to this file. If your function is not part of a class, you will need to add it manually.\n",
     "\n",
@@ -96,7 +96,7 @@
    "source": [
     "## What order arrays should be in\n",
     "\n",
-    "Because Matlab is using arrays in column major order, the libtopotoolbox is using them as well. While thats not forced for new functions anymore, the shape (dims) we pass along with our matrix has to match the matrix.\n",
+    "Because Matlab arrays are stored in column major order, the libtopotoolbox is using the same logic. While the introduction of the `dims[2]` argument added support for other approches, we still generally use the Fortran order.\n",
     "\n",
     "The following example will showcase what this means in practice."
    ]


### PR DESCRIPTION
This should contain all changes to the documentation originally made in #72 to add a guide for wrapping libtopotoolbox functions.

closes #76 