### PR TITLE
Implement `StreamObject.chitransform`

### DIFF
--- a/src/topotoolbox/flow_object.py
+++ b/src/topotoolbox/flow_object.py
@@ -104,6 +104,7 @@ class FlowObject():
         self.direction = direction  # dtype=np.unit8
         self.shape = grid.shape
         self.cellsize = grid.cellsize
+        self.strides = tuple(s // grid.z.itemsize for s in grid.z.strides)
 
         # georeference
         self.bounds = grid.bounds

--- a/src/topotoolbox/stream_object.py
+++ b/src/topotoolbox/stream_object.py
@@ -179,6 +179,22 @@ class StreamObject():
         self.path = flow.path
         self.name = flow.name
 
+    def distance(self) -> np.ndarray:
+        """
+        Compute the pixel-to-pixel distance for each edge.
+
+        Returns
+        -------
+        np.ndarray, float32
+            An edge attribute list with the distance between pixels
+        """
+        d = np.abs(self.stream[self.source] - self.stream[self.target])
+
+        dist = self.cellsize * np.where((d == self.strides[0]) | (d == self.strides[1]),
+                                        np.float32(1.0),
+                                        np.sqrt(np.float32(2.0)))
+
+        return dist
     def show(self, cmap='hot', overlay: GridObject | None = None,
              overlay_cmap: str = 'binary', alpha: float = 0.8) -> None:
         """

--- a/src/topotoolbox/stream_object.py
+++ b/src/topotoolbox/stream_object.py
@@ -195,6 +195,32 @@ class StreamObject():
                                         np.sqrt(np.float32(2.0)))
 
         return dist
+
+    def ezgetnal(self,
+                 k):
+        """
+        Retrieve a node attribute list from k
+        """
+
+        if isinstance(k, GridObject):
+            nal = k.z[np.unravel_index(self.stream, self.shape, order='F')]
+        elif isinstance(k, np.ndarray):
+            if k.shape == self.shape:
+                # We have passed an ndarray with the same shape as the
+                # corresponding GridObject, index into it
+                nal = k[np.unravel_index(self.stream, self.shape, order='F')]
+            elif k.shape == self.stream.shape:
+                # k is already a node attribute list
+                nal = k
+            else:
+                raise ValueError(f"{k} is not of the appropriate shape")
+        elif np.isscalar(k):
+            nal = np.full(np.stream.shape, k)
+        else:
+            raise TypeError(f"{k} is not a supported source for a node attribute list")
+
+        return nal
+
     def show(self, cmap='hot', overlay: GridObject | None = None,
              overlay_cmap: str = 'binary', alpha: float = 0.8) -> None:
         """

--- a/src/topotoolbox/stream_object.py
+++ b/src/topotoolbox/stream_object.py
@@ -198,9 +198,29 @@ class StreamObject():
         return dist
 
     def ezgetnal(self,
-                 k):
-        """
-        Retrieve a node attribute list from k
+                 k : GridObject | np.ndarray | float):
+        """Retrieve a node attribute list from k
+
+        Parameters
+        ----------
+        k : GridObject | np.ndarray | float
+            The object from which node values will be extracted. If
+            `k` is a `GridObject` or an `np.ndarray` with the same
+            shape as the underlying DEM of this `StreamObject`, the
+            node values will be extracted from the grid by
+            indexing. If `k` is an array with the same shape as the
+            node attribute list, `ezgetnal` returns `k`. If `k` is a
+            scalar value, `ezgetnal` returns an array of the right
+            shape filled with `k`.
+
+        Raises
+        ------
+        ValueError
+            If `k` does not have the right shape to be indexed by the
+            `StreamObject`.
+        TypeError
+            If `k` does not represent a type of data that can be
+            extracted into a node attribute list.
         """
 
         if isinstance(k, GridObject):
@@ -216,7 +236,7 @@ class StreamObject():
             else:
                 raise ValueError(f"{k} is not of the appropriate shape")
         elif np.isscalar(k):
-            nal = np.full(np.stream.shape, k)
+            nal = np.full(self.stream.shape, k)
         else:
             raise TypeError(f"{k} is not a supported source for a node attribute list")
 
@@ -270,6 +290,44 @@ class StreamObject():
         longitudinal profile using an integration in upstream
         direction of drainage area (chi, see Perron and Royden, 2013).
 
+        Parameters
+        ----------
+        upstream_area : GridObject | np.ndarray
+            Raster with the upstream areas. Must be the same size and
+            projection as the GridObject used to create the
+            StreamObject.
+        a0 : float, optional
+            Reference area in the same units as the upstream_area
+            raster. Defaults to 100_000.
+        mn : float, optional
+            mn-ratio. Defaults to 0.45.
+        k  : GridObject | np.ndarray | None, optional
+            Erosional efficiency, which may vary spatially. If `k` is
+            supplied, then `chitransform` returns the time needed for
+            a signal (knickpoint) propagating upstream from the outlet
+            of the stream network. If `k` has units of m^(1 - 2m) / y,
+            then time will have units of y. Note that calculating the
+            response time requires the assumption that n=1. Defaults
+            to None, which does not use the erosional efficiency.
+        correctcellsize : bool, optional
+            If true, multiplies the `upstream_area` raster by
+            `self.cellsize**2`. Use if `a0` has the same units of
+            `self.cellsize**2` and `upstream_area` has units of
+            pixels, such as the default output from
+            `flow_accumulation`. If the units of `upstream_area` are
+            already m^2, then set correctcellsize to False. Defaults
+            to True.
+
+        Raises
+        ------
+        ValueError
+            If `upstream_area` or `k` does not have the right shape to
+            be indexed by the `StreamObject`.
+        TypeError
+            If `upstream_area` or `k` does not represent a type of data that can be
+            extracted into a node attribute list.
+        TypeError
+            If the modified upstream area is not a supported floating point type.
         """
 
         # Retrieve node attribute lists

--- a/src/topotoolbox/stream_object.py
+++ b/src/topotoolbox/stream_object.py
@@ -58,6 +58,7 @@ class StreamObject():
 
         self.cellsize = flow.cellsize
         self.shape = flow.shape
+        self.strides = flow.strides
 
         # georeference
         self.bounds = flow.bounds

--- a/tests/test_stream_object.py
+++ b/tests/test_stream_object.py
@@ -7,27 +7,34 @@ import topotoolbox as topo
 
 @pytest.fixture
 def wide_dem():
-    dem = topo.gen_random(rows=128, columns=64)
-    flow = topo.FlowObject(dem)
-    yield topo.StreamObject(flow)
-
+    yield topo.gen_random(rows=128, columns=64)
 
 @pytest.fixture
 def tall_dem():
-    dem = topo.gen_random(rows=64, columns=128)
-    flow = topo.FlowObject(dem)
-    yield topo.StreamObject(flow)
-
+    yield topo.gen_random(columns=64, rows=128)
 
 def test_init(tall_dem, wide_dem):
-    assert (wide_dem.target.size == wide_dem.source.size ==
-            wide_dem.direction.size)
-    assert (tall_dem.target.size == tall_dem.source.size ==
-            tall_dem.direction.size)
+    tall_flow = topo.FlowObject(tall_dem)
+    tall_stream = topo.StreamObject(tall_flow)
+
+    wide_flow = topo.FlowObject(wide_dem)
+    wide_stream = topo.StreamObject(wide_flow)
+
+    assert (wide_stream.target.size == wide_stream.source.size ==
+            wide_stream.direction.size)
+    assert (tall_stream.target.size == tall_stream.source.size ==
+            tall_stream.direction.size)
 
     # Ensure that no index in stream exceeds the max possible index in the grid
-    assert np.max(wide_dem.stream) <= wide_dem.shape[0] * wide_dem.shape[1]
-    assert np.max(tall_dem.stream) <= tall_dem.shape[0] * tall_dem.shape[1]
+    assert np.max(wide_stream.stream) <= wide_stream.shape[0] * wide_stream.shape[1]
+    assert np.max(tall_stream.stream) <= tall_stream.shape[0] * tall_stream.shape[1]
+
+    tall_acc = tall_flow.flow_accumulation()
+    wide_acc = wide_flow.flow_accumulation()
+
+    # Run the chi transforms
+    tall_stream.chitransform(tall_acc)
+    wide_stream.chitransform(wide_acc)
 
     grid_obj = topo.gen_random(rows=64, columns=64)
     flow_obj = topo.FlowObject(grid_obj)


### PR DESCRIPTION
This series of commits implements the chi transform for `StreamObject`, resolving #75. It uses `streamquad_trapz` from libtopotoolbox to perform the numerical integration. Everything else sets up the data to be integrated.

There is a new `StreamObject.distance` method that returns the interpixel distance for each edge in the stream network. This is not identical to the `STREAMobj.distance` method that computes upstream distance in MATLAB. It is needed to compute the integration weights.

`StreamObject.ezgetnal` extracts node attributes from a `GridObject` or an `ndarray`. It does not do all of the shape and projection validation that `STREAMobj.ezgetnal` does, so be careful not to pass unaligned grids.

This has been tested manually on the perfectworld DEM, where it agrees with MATLAB's `STREAMobj.chitransform` with some floating-point error. Fully automated testing on real DEMs is slightly complicated because libtopotoolbox-based flow routing does not currently give identical answers when there are flat areas. However, it should be possible to test the `chitransform` itself by constructing a `StreamObject` directly and verifying that it gives the expected result.