### PR TITLE
Add erode to GridObject

### DIFF
--- a/src/topotoolbox/grid_object.py
+++ b/src/topotoolbox/grid_object.py
@@ -520,37 +520,45 @@ class GridObject():
             self, size: tuple | None = None, footprint: np.ndarray | None = None,
             structure: np.ndarray | None = None) -> 'GridObject':
         """Apply a morphological erosion operation to the GridObject. Either
-        size, footprint or structure has to be passed to this function.
-        Otherwise, a default size will be used.
+        size, footprint or structure has to be passed to this function. If
+        nothing is provided, the function will raise an error.
 
         Parameters
         ----------
         size : tuple of ints
             A tuple of ints containing the shape of the structuring element.
-            Only needed if neither footprint nor structure is provided.
-            Defaults to (3,3)
+            Only needed if neither footprint nor structure is provided. Will
+            result in a full and flat structuring element.
+            Defaults to None
         footprint : np.ndarray of ints, optional
-            A boolean array defining the footprint of the erosion operation.
+            A array defining the footprint of the erosion operation.
             Non-zero elements define the neighborhood over which the erosion
-            is applied. If None, the default is a full 
-            connectivity neighborhood.
+            is applied. Defaults to None
         structure : np.ndarray of ints, optional
-            A structuring element used for the erosion. This defines the 
-            connectivity of the elements. If None, a flat structuring element
-            is used.
+            A array defining the structuring element used for the erosion. 
+            This defines the connectivity of the elements. Defaults to None
 
         Returns
         -------
         GridObject
-            A GridObject storing the computed values."""
+            A GridObject storing the computed values.
+
+        Raises
+        ------
+        ValueError
+            If size, structure and footprint are all None."""
+
+        if size is None and structure is None and footprint is None:
+            err = ("Erode requires a structuring element to be specified."
+                   " Use the size argument for a full and flat structuring"
+                   " element (equivalent to a a minimum filter) or the"
+                   " structure and footprint arguments to specify"
+                   " a non-flat structuring element.")
+            raise ValueError(err) from None
 
         # Replace NaN values with inf
         dem = self.z.copy()
         dem[np.isnan(dem)] = np.inf
-
-        if size is None and (structure is None and footprint is None):
-            # TODO: choose default vaule
-            size = (3, 3)
 
         eroded = grey_erosion(
             dem, size=size, structure=structure, footprint=footprint)

--- a/src/topotoolbox/grid_object.py
+++ b/src/topotoolbox/grid_object.py
@@ -516,17 +516,24 @@ class GridObject():
         result.z = curvature
         return result
 
-    def erode(self, footprint: np.ndarray = None, structure: np.ndarray = None) -> 'GridObject':
-        """Apply a morphological erosion operation to the GridObject.
+    def erode(self, size: tuple = None, footprint: np.ndarray = None,
+              structure: np.ndarray = None) -> 'GridObject':
+        """Apply a morphological erosion operation to the GridObject. Either
+        size, footprint or structure has to be passed to this function.
+        Otherwise, a default size will be used.
 
         Parameters
         ----------
-        footprint : np.ndarray, optional
+        size : tuple of ints
+            A tuple of ints containing the shape of the structuring element.
+            Only needed if neither footprint nor structure is provided.
+            Defaults to (3,3)
+        footprint : np.ndarray of ints, optional
             A boolean array defining the footprint of the erosion operation.
             Non-zero elements define the neighborhood over which the erosion
             is applied. If None, the default is a full 
             connectivity neighborhood.
-        structure : np.ndarray, optional
+        structure : np.ndarray of ints, optional
             A structuring element used for the erosion. This defines the 
             connectivity of the elements. If None, a flat structuring element
             is used.
@@ -537,10 +544,15 @@ class GridObject():
             A GridObject storing the computed values."""
 
         # Replace NaN values with inf
-        dem = self.z[np.isnan(self.z)] = np.inf
+        dem = self.z.copy()
+        dem[np.isnan(dem)] = np.inf
 
-        eroded = grey_erosion(dem, structure=structure,
-                              footprint=footprint.astype(bool))
+        if size is None and (structure is None and footprint is None):
+            # TODO: choose default vaule
+            size = (3, 3)
+
+        eroded = grey_erosion(
+            dem, size=size, structure=structure, footprint=footprint)
 
         # Keep NaNs like they are in dem
         eroded[np.isnan(self.z)] = np.nan

--- a/src/topotoolbox/grid_object.py
+++ b/src/topotoolbox/grid_object.py
@@ -516,8 +516,9 @@ class GridObject():
         result.z = curvature
         return result
 
-    def erode(self, size: tuple = None, footprint: np.ndarray = None,
-              structure: np.ndarray = None) -> 'GridObject':
+    def erode(
+            self, size: tuple | None = None, footprint: np.ndarray | None = None,
+            structure: np.ndarray | None = None) -> 'GridObject':
         """Apply a morphological erosion operation to the GridObject. Either
         size, footprint or structure has to be passed to this function.
         Otherwise, a default size will be used.


### PR DESCRIPTION
This adds the `erode()` function to the `GridObject`. It wraps the `scipy.ndimage.grey_erosion()` function. Like in the Matlab wrapper, all NaNs are set to `inf` before running the erosion and reverted to NaNs afterward. 

The [Matlab](https://de.mathworks.com/help/images/ref/imerode.html#d126e161642) wrapper only supports the argument `SE` (Structuring element) and ignores `nhood`. In the [Python](https://docs.scipy.org/doc/scipy/reference/generated/scipy.ndimage.grey_erosion.html) implementation, `footprint` is `nhood` and `structure` is `SE`. I kept both (and `size`) so provide as much customizability as possible to the user.

Right now, the function defaults to size=(3,3) if nothing else is provided. There is no specific reasoning behind that, so if you have a suggestion what the default should be, I will adjust that. @wkearn (The pipeline is failing because there is still this TODO in the file)

closes #105 