### PR TITLE
Add dilate to GridObject

### DIFF
--- a/src/topotoolbox/grid_object.py
+++ b/src/topotoolbox/grid_object.py
@@ -5,7 +5,7 @@ import copy
 import numpy as np
 import matplotlib.pyplot as plt
 
-from scipy.ndimage import convolve, median_filter, generic_filter
+from scipy.ndimage import convolve, median_filter, generic_filter, grey_dilation
 from scipy.signal import wiener
 from rasterio import CRS
 from rasterio.warp import reproject
@@ -514,6 +514,59 @@ class GridObject():
 
         result = copy.copy(self)
         result.z = curvature
+        return result
+
+    def dilate(
+            self, size: tuple | None = None, footprint: np.ndarray | None = None,
+            structure: np.ndarray | None = None) -> 'GridObject':
+        """A simple wrapper around th scipy.ndimage.grey_dilation function,
+        that also handles NaNs in the input GridObject. Either size, footprint
+        or structure has to be passed to this function. If nothing is provided,
+        the function will raise an error.
+
+        size : tuple of ints, optional
+            A tuple of ints containing the shape of the structuring element.
+            Only needed if neither footprint nor structure is provided. Will
+            result in a full and flat structuring element.
+            Defaults to None
+        footprint : np.ndarray of ints, optional
+            A array defining the footprint of the erosion operation.
+            Non-zero elements define the neighborhood over which the erosion
+            is applied. Defaults to None
+        structure : np.ndarray of ints, optional
+            A array defining the structuring element used for the erosion. 
+            This defines the connectivity of the elements. Defaults to None
+
+        Returns
+        -------
+        GridObject
+            A GridObject storing the computed values.
+        Raises
+        ------
+        ValueError
+            If size, structure and footprint are all None.
+        """
+
+        if size is None and structure is None and footprint is None:
+            err = ("Dilate requires a structuring element to be specified."
+                   " Use the size argument for a full and flat structuring"
+                   " element (equivalent to a a minimum filter) or the"
+                   " structure and footprint arguments to specify"
+                   " a non-flat structuring element.")
+            raise ValueError(err) from None
+
+        # Replace NaN values with inf
+        dem = self.z.copy()
+        dem[np.isnan(dem)] = -np.inf
+
+        dilated = grey_dilation(
+            input=dem, size=size, structure=structure, footprint=footprint)
+
+        # Keep NaNs like they are in dem
+        dilated[np.isnan(self.z)] = np.nan
+
+        result = copy.copy(self)
+        result.z = dilated
         return result
 
     def _gwdt_computecosts(self) -> np.ndarray:


### PR DESCRIPTION
This adds the dilate function to the `GridObject.` Basically the same code as `erode` #105 but using `grey_dilation`. Also `-inf` in place of `inf` when replacing NaNs. Will probably cause merge conflicts after #116 is merged.

closes #104 