### PR TITLE
Add curvature to the Getting Started guide

### DIFF
--- a/docs/tutorial/grid.ipynb
+++ b/docs/tutorial/grid.ipynb
@@ -17,7 +17,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import topotoolbox as tt3"
+    "import topotoolbox as tt3\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt"
    ]
   },
   {
@@ -39,7 +41,49 @@
    "source": [
     "dem = tt3.load_dem('tibet')\n",
     "g = dem.gradient8()\n",
-    "g.show(cmap='magma')"
+    "\n",
+    "fig0,ax0 = plt.subplots(1,1)\n",
+    "im0 = ax0.imshow(g,cmap='magma')\n",
+    "plt.colorbar(im0);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "51f5b1fc-077f-41f6-81cd-44c2ad4fea16",
+   "metadata": {},
+   "source": [
+    "## Curvature\n",
+    "\n",
+    "Curvature is the second derivative and measures the rate of change of slope. Profile curvature is the rate of slope change in direction of the maximum gradient. Conversely, planform curvature measures the curvature of the contour lines. The function curvature allows calculating both types of curvature in addition to some additionally, less frequently used forms of curvature. Curvature is very sensitive to errors in the DEM. Thus, when plotting, we only plot the data between the 2nd and 98th percentile of the data using Numpy's `quantile` function."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "03a140a8-49c9-45c2-bba7-10514f799bfd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cplan = dem.curvature(ctype='planc')\n",
+    "cprof = dem.curvature(ctype='profc');"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1ea1ac4c-23f1-44ed-9ba7-b6b9366b5ffb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, (ax1, ax2) = plt.subplots(2,1,layout='constrained')\n",
+    "clims1 = np.quantile(cplan,[0.02,0.98])\n",
+    "im1 = ax1.imshow(cplan,vmin=clims1[0],vmax=clims1[1])\n",
+    "plt.colorbar(im1)\n",
+    "\n",
+    "im2 = ax2.imshow(cprof)\n",
+    "clims2 = np.quantile(cprof,[0.02,0.98])\n",
+    "im2 = ax2.imshow(cprof,vmin=clims2[0],vmax=clims2[1])\n",
+    "plt.colorbar(im2);"
    ]
   }
  ],


### PR DESCRIPTION
Resolves #108

This commit copies the Curvature section from MATLAB's documentation. It implements percentile clipping of the data using Numpy's quantile function and matplotlib's vmin and vmax arguments to imshow.