### PR TITLE
Add Evansslope to GridObject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,4 +50,5 @@ disable = [
     "duplicate-code",
     "cyclic-import",
     "too-many-positional-arguments",
+    "too-many-lines",
 ]

--- a/src/topotoolbox/grid_object.py
+++ b/src/topotoolbox/grid_object.py
@@ -1,6 +1,7 @@
 """This module contains the GridObject class.
 """
 import copy
+from typing import Tuple
 
 import numpy as np
 import matplotlib.pyplot as plt
@@ -631,7 +632,7 @@ class GridObject():
 
     def evansslope(
             self, partial_derivitives: bool = False, mode: str = 'nearest',
-            modified: bool = False) -> 'GridObject':
+            modified: bool = False) -> 'GridObject' | Tuple['GridObject', 'GridObject']:
         """Evans method fits a second-order polynomial to 3x3 subgrids. The
         parameters of the polynomial are the partial derivatives which are
         used to calculate the surface slope = sqrt(Gx**2 + Gy**2).

--- a/src/topotoolbox/grid_object.py
+++ b/src/topotoolbox/grid_object.py
@@ -628,6 +628,23 @@ class GridObject():
         result.z = eroded
         return result
 
+    def evansslope(
+            self, padval: str = 'replicate', modified: bool = False,
+            remove_nans: bool = True) -> 'GridObject':
+
+        dem = self.z.copy()
+        if remove_nans:
+            # TODO: NaN replacement should be nearest
+            dem[np.isnan(dem)] = 0
+
+        kx = np.array(
+            [[-1, 0, 1], [-1, 0, 1], [-1, 0, 1]])/(6*self.cellsize)
+        fx = convolve(dem, kx, mode='nearest')
+        # kernel for dz/dy
+        ky = np.array(
+            [[1, 1, 1], [0, 0, 0], [-1, -1, -1]])/(6*self.cellsize)
+        fy = convolve(dem, ky, mode='nearest')
+
     def _gwdt_computecosts(self) -> np.ndarray:
         """
         Compute the cost array used in the gradient-weighted distance


### PR DESCRIPTION
This pull request adds the `evansslope` function to the `GridObject`. There are a few differences to the Matlab implementation:

- removed `removenans` argument, since `scipy.ndimage.convolve` needs NaNs to be removed (so it's always replacing NaNs with nearest neighbor)
- `padval` is renamed `mode`, to better reflect the underlying scipy function.
- Added `partial_derivitives` argument to provide the option to return fx and fy like in Matlab
- removed a bunch of code used for padding the DEM, since the padding is handled in the `convolution` function

I also had to disable the `too-many-lines` pylint error since the file is now larger than 1000 lines.

closes #106