### PR TITLE
Implement drainagebasins

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ include(FetchContent)
 FetchContent_Declare(
   topotoolbox
   GIT_REPOSITORY https://github.com/TopoToolbox/libtopotoolbox.git
-  GIT_TAG 2024-W46
+  GIT_TAG 8aa5ec825d83b66742914d17753c054580834684
 )
 FetchContent_MakeAvailable(topotoolbox)
 

--- a/src/lib/flow.cpp
+++ b/src/lib/flow.cpp
@@ -49,9 +49,22 @@ void wrap_flow_accumulation(
     flow_accumulation(acc_ptr, source_ptr, direction_ptr, weights_ptr, dims_ptr);
 }
 
+void wrap_drainagebasins(py::array_t<ptrdiff_t> basins,
+                         py::array_t<ptrdiff_t> source,
+                         py::array_t<ptrdiff_t> target,
+                         std::tuple<ptrdiff_t, ptrdiff_t> dims) {
+  ptrdiff_t *basins_ptr = basins.mutable_data();
+  ptrdiff_t *source_ptr = source.mutable_data();
+  ptrdiff_t *target_ptr = target.mutable_data();
+  ptrdiff_t dims_array[2] = {std::get<0>(dims), std::get<1>(dims)};
+
+  drainagebasins(basins_ptr, source_ptr, target_ptr, dims_array);
+}
+
 // Make wrap_funcname() function available as grid_funcname() to be used by
 // by functions in the pytopotoolbox package
 
 PYBIND11_MODULE(_flow, m) {
-    m.def("flow_accumulation", &wrap_flow_accumulation);
+  m.def("flow_accumulation", &wrap_flow_accumulation);
+  m.def("drainagebasins", &wrap_drainagebasins);
 }

--- a/src/topotoolbox/flow_object.py
+++ b/src/topotoolbox/flow_object.py
@@ -164,6 +164,32 @@ class FlowObject():
 
         return result
 
+    def drainagebasins(self):
+        """Delineate drainage basins from a flow network.
+
+        Returns
+        -------
+        GridObject
+            An integer-valued GridObject with a unique label for each drainage
+            basin.
+        """
+        basins = np.zeros(self.shape, dtype=np.int64, order='F')
+
+        _flow.drainagebasins(basins, self.source, self.target, self.shape)
+
+        result = GridObject()
+        result.path = self.path
+        result.name = self.name
+
+        result.z = basins
+        result.cellsize = self.cellsize
+
+        result.bounds = self.bounds
+        result.transform = self.transform
+        result.crs = self.crs
+
+        return result
+
     # 'Magic' functions:
     # ------------------------------------------------------------------------
 


### PR DESCRIPTION
This adds a pybind11 wrapper to the _flow module and a method to FlowObject for drainagebasins. Only the full drainagebasins computation is currently supported.

CMakeLists.txt is modified to use an appropriate commit of libtopotoolbox. This can be updated to 2025-W02 or later upon that release.

Resolves #110