### PR TITLE
Add shufflelabel method to GridObject

### DIFF
--- a/src/topotoolbox/grid_object.py
+++ b/src/topotoolbox/grid_object.py
@@ -803,6 +803,27 @@ class GridObject():
         plt.tight_layout()
         plt.show()
 
+    def shufflelabel(self):
+        """Randomize the labels of a GridObject
+
+        This function is helpful when plotting drainage basins. It will work with
+        any kind of data, but is most useful when given ordinal data such as an
+        integer-valued GridObject.
+
+        Returns
+        -------
+        GridObject
+          A grid identical to the input, but with randomly reassigned labels.
+        """
+        result = copy.copy(self)
+
+        labels = self.z
+        u,indices = np.unique(labels,return_inverse=True)
+        result.z = np.random.permutation(u)[indices]
+
+        return result
+
+
     # 'Magic' functions:
     # ------------------------------------------------------------------------
 


### PR DESCRIPTION
This is useful for plotting drainage basins, and is needed for the Getting Started guide section on `drainagebasins`.