### PR TITLE
Add Drainage basin delineation section to the Getting Started guide

### DIFF
--- a/docs/tutorial/flow.ipynb
+++ b/docs/tutorial/flow.ipynb
@@ -48,6 +48,27 @@
     "acc = fd.flow_accumulation()\n",
     "acc.show(cmap='Blues')"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ca245fef-bb15-4f94-bd7a-514a0c4d13a7",
+   "metadata": {},
+   "source": [
+    "## Drainage basin delineation\n",
+    "\n",
+    "Catchments can be derived using the function `drainagebasins`. The function returns a `GridObject` with integer values (a label grid). To make it easier to visualize the catchments, one can randomize the labels of the grid with `shufflelabel`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c875d034-da6a-4df5-a676-2d74441e15d8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "D = fd.drainagebasins()\n",
+    "D.shufflelabel().show(cmap=\"Pastel1\")"
+   ]
   }
  ],
  "metadata": {
@@ -66,7 +87,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.12"
+   "version": "3.11.2"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This copies the text from the MATLAB Getting Started guide, but adds an explanation for `shufflelabel` and uses a different color scheme to plot the drainage basins.

The resulting drainage basins look a little weird, but that is because of our known problems routing flow over flat
regions (TopoToolbox/libtopotoolbox#122).