### PR TITLE
Make fillsinks memory-order agnostic

### DIFF
--- a/src/topotoolbox/grid_object.py
+++ b/src/topotoolbox/grid_object.py
@@ -173,9 +173,9 @@ class GridObject():
 
         if hybrid:
             queue = np.zeros_like(dem, dtype=np.int64)
-            _grid.fillsinks_hybrid(output, queue, dem, bc, self.shape)
+            _grid.fillsinks_hybrid(output, queue, dem, bc, self.dims)
         else:
-            _grid.fillsinks(output, dem, bc, self.shape)
+            _grid.fillsinks(output, dem, bc, self.dims)
 
         if restore_nans:
             dem[nans] = np.nan

--- a/src/topotoolbox/grid_object.py
+++ b/src/topotoolbox/grid_object.py
@@ -64,6 +64,18 @@ class GridObject():
         """
         return self.z.shape[1]
 
+    @property
+    def dims(self):
+        """The dimensions of the grid in the correct order for libtopotoolbox
+        """
+        if self.z.flags.c_contiguous:
+            return (self.columns, self.rows)
+
+        if self.z.flags.f_contiguous:
+            return (self.rows, self.columns)
+
+        raise TypeError("Grid is not stored as a contiguous row- or column-major array")
+
     def reproject(self,
                   crs: 'CRS',
                   resolution: 'float | None' = None,

--- a/src/topotoolbox/grid_object.py
+++ b/src/topotoolbox/grid_object.py
@@ -149,7 +149,7 @@ class GridObject():
 
         """
 
-        dem = self.z.astype(np.float32, order='F')
+        dem = self.z.astype(np.float32)
         output = np.zeros_like(dem)
 
         restore_nans = False

--- a/tests/test_grid_object.py
+++ b/tests/test_grid_object.py
@@ -78,12 +78,22 @@ def test_fillsinks_order():
     dem_C = topo.GridObject()
     dem_C.z = 64 * (opensimplex.noise2array(x,y) + 1)
 
+    assert dem_C.shape[0] == 256
+    assert dem_C.shape[1] == 128
+    
     assert dem_C.z.flags.c_contiguous
+    assert dem_C.dims[0] == 128
+    assert dem_C.dims[1] == 256
     
     dem_F = topo.GridObject()
     dem_F.z = np.asfortranarray(dem_C.z)
 
+    assert dem_F.shape[0] == 256
+    assert dem_F.shape[1] == 128
+    
     assert dem_F.z.flags.f_contiguous
+    assert dem_F.dims[0] == 256
+    assert dem_F.dims[1] == 128
 
     filled_C = dem_C.fillsinks()
     assert filled_C.z.flags.c_contiguous

--- a/tests/test_grid_object.py
+++ b/tests/test_grid_object.py
@@ -3,6 +3,8 @@ import pytest
 
 import topotoolbox as topo
 
+import opensimplex
+
 
 @pytest.fixture
 def square_dem():
@@ -67,6 +69,30 @@ def test_fillsinks(square_dem, wide_dem, tall_dem):
                 assert sink < 8
 
 
+def test_fillsinks_order():
+    opensimplex.seed(12)
+
+    x = np.arange(0,128)
+    y = np.arange(0,256)
+
+    dem_C = topo.GridObject()
+    dem_C.z = 64 * (opensimplex.noise2array(x,y) + 1)
+
+    assert dem_C.z.flags.c_contiguous
+    
+    dem_F = topo.GridObject()
+    dem_F.z = np.asfortranarray(dem_C.z)
+
+    assert dem_F.z.flags.f_contiguous
+
+    filled_C = dem_C.fillsinks()
+    assert filled_C.z.flags.c_contiguous
+    
+    filled_F = dem_F.fillsinks()    
+    assert filled_F.z.flags.f_contiguous
+   
+    assert np.array_equal(filled_F.z, filled_C.z)
+    
 def test_identifyflats(square_dem, wide_dem, tall_dem):
     # TODO: add more tests
     for dem in [square_dem, wide_dem, tall_dem]:


### PR DESCRIPTION
This represents one way that we might make our interface with libtopotoolbox agnostic to the memory order of our underlying numpy arrays. I have added a property `dims` to `GridObject`, which reverses the order of the dimensions if the array is in row-major layout. `GridObject.shape` still returns `(rows, columns)`. If we pass `self.dims` instead of `self.shape` to the `fillsinks` wrapper, we will now get the same, correct, answer if the `GridObject.z` array is column- or row-major. There is also a test that confirms this behavior.

I did notice some unexpected changes in performance after implementing this. I thought it would tend to speed `fillsinks` up when using row-major data by avoiding the unnecessary copy to column major. However, this was not the case when applying `fillsinks` to the Big Tujunga data, loaded in row-major format. It takes around 25 ms on my machine to run `fillsinks` on the column-major data and 33 ms on the row-major data. 

I believe that this is not a problem with our implementation, but instead dependent on the data. `fillsinks` is a global computation, and the amount of work it has to do depends on the orientation of features in the image. The Taiwan DEM performs better in row-major layout, and if I transpose the Big Tujunga DEM, the performance numbers swap: row-major takes around 33 ms and column-major takes around 25 ms.