### PR TITLE
Add test dependencies as an optional dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,10 @@ classifiers = []
 
 [project.optional-dependencies]
 opensimplex = ["opensimplex"]
+test = [
+     "pytest",
+     "opensimplex"
+]
 
 [project.urls]
 Homepage = "https://topotoolbox.github.io"


### PR DESCRIPTION
The changes in #125 use opensimplex directly in the tests, and I wanted to be clear that you need opensimplex to run the tests. I left the "opensimplex" optional dependency in there to avoid breaking existing workflows and because it does provide functionality that we use outside of the tests.

I also added pytest to the "test" dependency. I believe this is the only other package we use directly. All of the other test dependencies are transitive dependencies. Cleanly installing everything using `pip install .[test]` in a new virtual environment works, and the tests are able to run successfully.

I did not add version constraints here because I am not sure if there is a minimum version of either pytest or opensimplex we need to run the tests successfully. I remember we some discussion in #68 about trying not to duplicate information across the `pyproject.toml` and `requirements.txt`, but they serve different purposes: `requirements.txt` ensures that we have a consistent environment that we use when testing the package, while `pyproject.toml` makes sure that everything that is necessary to use or test the package gets installed properly, and that packages that might depend on pytopotoolbox get installed properly.. We shouldn't pin versions in pyproject.toml (see #77), but if there are minimum versions that we need to use pytopotoolbox functionality, we can add those constraints.