### PR TITLE
Add downstream_distance method to StreamObject

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ include(FetchContent)
 FetchContent_Declare(
   topotoolbox
   GIT_REPOSITORY https://github.com/TopoToolbox/libtopotoolbox.git
-  GIT_TAG 8aa5ec825d83b66742914d17753c054580834684
+  GIT_TAG 9b2102a6fc032e18879b996bd06ddc4a537c2af5
 )
 FetchContent_MakeAvailable(topotoolbox)
 

--- a/src/lib/stream.cpp
+++ b/src/lib/stream.cpp
@@ -51,7 +51,41 @@ void wrap_streamquad_trapz_f64(py::array_t<double> integral,
                        weight_ptr, edge_count);
 }
 
+void wrap_traverse_up_u32_and(py::array_t<uint32_t> output,
+                              py::array_t<uint32_t> input,
+                              py::array_t<ptrdiff_t> source,
+                              py::array_t<ptrdiff_t> target) {
+
+  uint32_t *output_ptr = output.mutable_data();
+  uint32_t *input_ptr = input.mutable_data();
+  ptrdiff_t *source_ptr = source.mutable_data();
+  ptrdiff_t *target_ptr = target.mutable_data();
+
+  ptrdiff_t edge_count = source.size(); 
+
+  traverse_up_u32_and(output_ptr, input_ptr, source_ptr,
+                      target_ptr, edge_count);  
+}
+
+void wrap_traverse_down_f32_max_add(py::array_t<float> output,
+                                    py::array_t<float> input,
+                                    py::array_t<ptrdiff_t> source,
+                                    py::array_t<ptrdiff_t> target) {
+
+  float *output_ptr = output.mutable_data();
+  float *input_ptr = input.mutable_data();
+  ptrdiff_t *source_ptr = source.mutable_data();
+  ptrdiff_t *target_ptr = target.mutable_data();
+
+  ptrdiff_t edge_count = source.size();
+
+  traverse_down_f32_max_add(output_ptr, input_ptr, source_ptr,
+                            target_ptr, edge_count);
+}
+
 PYBIND11_MODULE(_stream, m) {
   m.def("streamquad_trapz_f32", &wrap_streamquad_trapz_f32);
   m.def("streamquad_trapz_f64", &wrap_streamquad_trapz_f64);
+  m.def("traverse_up_u32_and", &wrap_traverse_down_f32_max_add);
+  m.def("traverse_down_f32_max_add", &wrap_traverse_down_f32_max_add);  
 }

--- a/src/topotoolbox/stream_object.py
+++ b/src/topotoolbox/stream_object.py
@@ -198,6 +198,22 @@ class StreamObject():
 
         return dist
 
+    def downstream_distance(self) -> np.ndarray:
+        """Compute the maximum distance between a node in the stream
+        network and the channel head.
+
+        Returns
+        -------
+        np.ndarray, float32
+            A node attribute list with the downstream distances
+        """
+
+        d = self.distance() # Edge attribute list
+        dds = np.zeros_like(self.stream, dtype=np.float32)
+        _stream.traverse_down_f32_max_add(dds, d, self.source + 1, self.target + 1)
+
+        return dds
+
     def ezgetnal(self,
                  k : GridObject | np.ndarray | float):
         """Retrieve a node attribute list from k


### PR DESCRIPTION
This uses libtopotoolbox's new traverse_down_f32_max_add to compute the maximum distance from a channel head for each node in the stream network.

As discussed in #113. The upstream traversal used to identify the stream with the maximum distance is implemented in libtopotoolbox and wrapped but not implemented in Python yet.