### PR TITLE
Pass zero-based source and target arrays to libtopotoolbox traversal

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ include(FetchContent)
 FetchContent_Declare(
   topotoolbox
   GIT_REPOSITORY https://github.com/TopoToolbox/libtopotoolbox.git
-  GIT_TAG 9b2102a6fc032e18879b996bd06ddc4a537c2af5
+  GIT_TAG 2615227a1fc0b1d2f9debc749027d720d4c6d6a6
 )
 FetchContent_MakeAvailable(topotoolbox)
 

--- a/src/topotoolbox/stream_object.py
+++ b/src/topotoolbox/stream_object.py
@@ -210,7 +210,7 @@ class StreamObject():
 
         d = self.distance() # Edge attribute list
         dds = np.zeros_like(self.stream, dtype=np.float32)
-        _stream.traverse_down_f32_max_add(dds, d, self.source + 1, self.target + 1)
+        _stream.traverse_down_f32_max_add(dds, d, self.source, self.target)
 
         return dds
 
@@ -403,19 +403,16 @@ class StreamObject():
         weight = self.distance()
         c = np.zeros_like(a)
         if a.dtype == np.float32:
-            # libtopotoolbox expects source and target to be 1-based
-            # indices into node attribute lists, so we must add 1 to
-            # source and target, which are zero-based indices.
             _stream.streamquad_trapz_f32(c,
                                          a,
-                                         self.source + 1,
-                                         self.target + 1,
+                                         self.source,
+                                         self.target,
                                          weight)
         elif a.dtype == np.float64:
             _stream.streamquad_trapz_f64(c,
                                          a,
-                                         self.source + 1,
-                                         self.target + 1,
+                                         self.source,
+                                         self.target,
                                          weight)
         else:
             # This is probably unreachable


### PR DESCRIPTION
Required after TopoToolbox/libtopotoolbox#165 changed the interface for stream network traversals. This uses the more recent commit of libtopotoolbox.