### PR TITLE
Use the new libtopotoolbox flow routing API

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ include(FetchContent)
 FetchContent_Declare(
   topotoolbox
   GIT_REPOSITORY https://github.com/TopoToolbox/libtopotoolbox.git
-  GIT_TAG 2615227a1fc0b1d2f9debc749027d720d4c6d6a6
+  GIT_TAG 2025-W06
 )
 FetchContent_MakeAvailable(topotoolbox)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ include(FetchContent)
 FetchContent_Declare(
   topotoolbox
   GIT_REPOSITORY https://github.com/TopoToolbox/libtopotoolbox.git
-  GIT_TAG 2025-W06
+  GIT_TAG 3458418513a5a92061c18a12bc02659de9ef1667
 )
 FetchContent_MakeAvailable(topotoolbox)
 

--- a/src/lib/flow.cpp
+++ b/src/lib/flow.cpp
@@ -35,18 +35,22 @@ namespace py = pybind11;
 //         rows and  columns) where flow accumulation is performed.
 
 void wrap_flow_accumulation(
-        py::array_t<float> acc, py::array_t<ptrdiff_t> source, 
-        py::array_t<uint8_t> direction, py::array_t<float> weights,
+        py::array_t<float> acc,
+        py::array_t<ptrdiff_t> source,
+        py::array_t<ptrdiff_t> target,
+        py::array_t<float> fraction,
+        py::array_t<float> weights,
         std::tuple<ptrdiff_t,ptrdiff_t> dims){
 
     float *acc_ptr = acc.mutable_data();
     ptrdiff_t *source_ptr = source.mutable_data();
-    uint8_t *direction_ptr = direction.mutable_data();
+    ptrdiff_t *target_ptr = target.mutable_data();
+    float *fraction_ptr = fraction.mutable_data();
     float *weights_ptr = weights.mutable_data();
     
     std::array<ptrdiff_t, 2> dims_array = {std::get<0>(dims), std::get<1>(dims)};
     ptrdiff_t *dims_ptr = dims_array.data();
-    flow_accumulation(acc_ptr, source_ptr, direction_ptr, weights_ptr, dims_ptr);
+    flow_accumulation_edgelist(acc_ptr, source_ptr, target_ptr, fraction_ptr, weights_ptr, source.size(), dims_ptr);
 }
 
 void wrap_drainagebasins(py::array_t<ptrdiff_t> basins,

--- a/src/lib/flow.cpp
+++ b/src/lib/flow.cpp
@@ -56,9 +56,10 @@ void wrap_drainagebasins(py::array_t<ptrdiff_t> basins,
   ptrdiff_t *basins_ptr = basins.mutable_data();
   ptrdiff_t *source_ptr = source.mutable_data();
   ptrdiff_t *target_ptr = target.mutable_data();
+  ptrdiff_t edge_count = source.size();
   ptrdiff_t dims_array[2] = {std::get<0>(dims), std::get<1>(dims)};
 
-  drainagebasins(basins_ptr, source_ptr, target_ptr, dims_array);
+  drainagebasins(basins_ptr, source_ptr, target_ptr, edge_count, dims_array);
 }
 
 // Make wrap_funcname() function available as grid_funcname() to be used by

--- a/src/lib/grid.cpp
+++ b/src/lib/grid.cpp
@@ -207,7 +207,7 @@ void wrap_flow_routing_d8_carve(
 //   direction: A NumPy array representing the computed flow directions.
 //   dims: A tuple containing the number of rows and columns.
 
-void wrap_flow_routing_d8_edgelist(
+ptrdiff_t wrap_flow_routing_d8_edgelist(
         py::array_t<ptrdiff_t> source,
         py::array_t<ptrdiff_t> target,
         py::array_t<ptrdiff_t> node,
@@ -222,7 +222,7 @@ void wrap_flow_routing_d8_edgelist(
 
     std::array<ptrdiff_t, 2> dims_array = {std::get<0>(dims), std::get<1>(dims)};
     ptrdiff_t *dims_ptr = dims_array.data();
-    flow_routing_d8_edgelist(source_ptr, target_ptr, node_ptr, direction_ptr, dims_ptr);    
+    return flow_routing_d8_edgelist(source_ptr, target_ptr, node_ptr, direction_ptr, dims_ptr);
 }
 
 // wrap_gradient8:

--- a/src/lib/grid.cpp
+++ b/src/lib/grid.cpp
@@ -174,7 +174,8 @@ void wrap_gwdt_computecosts(
 
 // wrap_flow_routing_d8_carve:
 // Parameters:
-//   source: A NumPy array representing the source cells for flow routing.
+//   node: A NumPy array representing the topologically sorted list of
+//         flow network vertices.
 //   direction: A NumPy array to store the computed flow directions.
 //   dem: A NumPy array representing the digital elevation model (DEM).
 //   dist: A NumPy array to store the computed flow distances.
@@ -182,11 +183,11 @@ void wrap_gwdt_computecosts(
 //   dims: A tuple containing the number of rows and columns.
 
 void wrap_flow_routing_d8_carve(
-        py::array_t<ptrdiff_t> source, py::array_t<uint8_t> direction, 
+        py::array_t<ptrdiff_t> node, py::array_t<uint8_t> direction, 
         py::array_t<float> dem, py::array_t<float> dist, 
         py::array_t<int32_t> flats, std::tuple<ptrdiff_t, ptrdiff_t> dims){
     
-    ptrdiff_t *source_ptr = source.mutable_data();
+    ptrdiff_t *node_ptr = node.mutable_data();
     uint8_t *direction_ptr = direction.mutable_data();
     float *dem_ptr = dem.mutable_data();
     float *dist_ptr = dist.mutable_data();
@@ -195,27 +196,33 @@ void wrap_flow_routing_d8_carve(
     std::array<ptrdiff_t, 2> dims_array = {std::get<0>(dims), std::get<1>(dims)};
     ptrdiff_t *dims_ptr = dims_array.data();
 
-    flow_routing_d8_carve(source_ptr, direction_ptr, dem_ptr, dist_ptr, flats_ptr, dims_ptr);
+    flow_routing_d8_carve(node_ptr, direction_ptr, dem_ptr, dist_ptr, flats_ptr, dims_ptr);
 }
 
-// wrap_flow_routing_targets:
+// wrap_flow_routing_d8_edgelist:
 // Parameters:
-//   target: A NumPy array to store the computed target cells for flow routing.
 //   source: A NumPy array representing the source cells for flow routing.
+//   target: A NumPy array to store the computed target cells for flow routing.
+//   node: A Numpy array containing the topologically sorted list of vertices.
 //   direction: A NumPy array representing the computed flow directions.
 //   dims: A tuple containing the number of rows and columns.
 
-void wrap_flow_routing_targets(
-        py::array_t<ptrdiff_t> target, py::array_t<ptrdiff_t> source,
-        py::array_t<uint8_t> direction, std::tuple<ptrdiff_t,ptrdiff_t> dims){
+void wrap_flow_routing_d8_edgelist(
+        py::array_t<ptrdiff_t> source,
+        py::array_t<ptrdiff_t> target,
+        py::array_t<ptrdiff_t> node,
+        py::array_t<uint8_t> direction,
+        std::tuple<ptrdiff_t,ptrdiff_t> dims) {
 
-    ptrdiff_t *target_ptr = target.mutable_data();
     ptrdiff_t *source_ptr = source.mutable_data();
+    ptrdiff_t *target_ptr = target.mutable_data();
+
+    ptrdiff_t *node_ptr = node.mutable_data();
     uint8_t *direction_ptr = direction.mutable_data(); 
 
     std::array<ptrdiff_t, 2> dims_array = {std::get<0>(dims), std::get<1>(dims)};
     ptrdiff_t *dims_ptr = dims_array.data();
-    flow_routing_targets(target_ptr, source_ptr, direction_ptr, dims_ptr);
+    flow_routing_d8_edgelist(source_ptr, target_ptr, node_ptr, direction_ptr, dims_ptr);    
 }
 
 // wrap_gradient8:
@@ -250,6 +257,6 @@ PYBIND11_MODULE(_grid, m) {
     m.def("gwdt", &wrap_gwdt);
     m.def("gwdt_computecosts", &wrap_gwdt_computecosts);
     m.def("flow_routing_d8_carve", &wrap_flow_routing_d8_carve);
-    m.def("flow_routing_targets", &wrap_flow_routing_targets);
+    m.def("flow_routing_d8_edgelist", &wrap_flow_routing_d8_edgelist);
     m.def("gradient8", &wrap_gradient8);
 }

--- a/src/topotoolbox/flow_object.py
+++ b/src/topotoolbox/flow_object.py
@@ -91,9 +91,9 @@ class FlowObject():
         _grid.flow_routing_d8_carve(
             node, direction, filled_dem, dist, flats, dims)
 
-        source = conncomps  # source: dtype=int64
-        target = back       # target: dtype=int64
-        _grid.flow_routing_d8_edgelist(source, target, node , direction, dims)
+        source = np.ravel(conncomps)  # source: dtype=int64
+        target = np.ravel(back)       # target: dtype=int64
+        edge_count = _grid.flow_routing_d8_edgelist(source, target, node, direction, dims)
 
         self.path = grid.path
         self.name = grid.name
@@ -102,8 +102,8 @@ class FlowObject():
 
         self.direction = direction  # dtype=np.unit8
 
-        self.source = source  # dtype=np.int64
-        self.target = target  # dtype=np.int64
+        self.source = source[0:edge_count]  # dtype=np.int64
+        self.target = target[0:edge_count]  # dtype=np.int64
 
         self.shape = grid.shape
         self.cellsize = grid.cellsize

--- a/src/topotoolbox/flow_object.py
+++ b/src/topotoolbox/flow_object.py
@@ -86,22 +86,25 @@ class FlowObject():
         back = np.zeros_like(flats, dtype=np.int64, order='F')
         _grid.gwdt(dist, prev, costs, flats, heap, back, dims)
 
-        source = heap  # source: dtype=np.int64
+        node = heap  # node: dtype=np.int64
         direction = np.zeros_like(dem, dtype=np.uint8, order='F')
         _grid.flow_routing_d8_carve(
-            source, direction, filled_dem, dist, flats, dims)
+            node, direction, filled_dem, dist, flats, dims)
 
-        target = back  # target: dtype=int64
-        _grid.flow_routing_targets(target, source, direction, dims)
+        source = conncomps  # source: dtype=int64
+        target = back       # target: dtype=int64
+        _grid.flow_routing_d8_edgelist(source, target, node , direction, dims)
 
         self.path = grid.path
         self.name = grid.name
 
         # raster metadata
 
-        self.target = target  # dtype=np.int64
-        self.source = source  # dtype=np.int64
         self.direction = direction  # dtype=np.unit8
+
+        self.source = source  # dtype=np.int64
+        self.target = target  # dtype=np.int64
+
         self.shape = grid.shape
         self.cellsize = grid.cellsize
         self.strides = tuple(s // grid.z.itemsize for s in grid.z.strides)

--- a/src/topotoolbox/flow_object.py
+++ b/src/topotoolbox/flow_object.py
@@ -139,10 +139,10 @@ class FlowObject():
             If the shape of the `weights` array does not match the shape of the
             flow network grid.
         """
-        acc = np.zeros_like(self.source, dtype=np.float32, order='F')
+        acc = np.zeros(self.shape, dtype=np.float32, order='F')
 
         if weights == 1.0:
-            weights = np.ones_like(self.source, dtype=np.float32, order='F')
+            weights = np.ones(self.shape, dtype=np.float32, order='F')
         elif isinstance(weights, np.ndarray):
             if weights.shape != acc.shape:
                 err = ("The shape of the provided weights ndarray does not "
@@ -151,8 +151,10 @@ class FlowObject():
         else:
             weights = np.full(self.shape, weights, dtype=np.float32, order='F')
 
+        fraction = np.ones_like(self.source, dtype=np.float32)
+
         _flow.flow_accumulation(
-            acc, self.source, self.direction, weights, self.shape)
+            acc, self.source, self.target, fraction, weights, self.shape)
 
         result = GridObject()
         result.path = self.path

--- a/src/topotoolbox/stream_object.py
+++ b/src/topotoolbox/stream_object.py
@@ -140,10 +140,11 @@ class StreamObject():
             threshold /= cell_area
 
             # Generate the flow accumulation matrix (acc)
-            acc = np.zeros_like(flow.target, order='F', dtype=np.float32)
-            weights = np.ones_like(flow.target, order='F', dtype=np.float32)
+            acc = np.zeros(flow.shape, order='F', dtype=np.float32)
+            fraction = np.zeros_like(flow.source, dtype=np.float32)
+            weights = np.ones(flow.shape, order='F', dtype=np.float32)
             _flow.flow_accumulation(
-                acc, flow.source, flow.direction, weights, flow.shape)
+                acc, flow.source, flow.target, fraction, weights, flow.shape)
 
             # Generate a 1D array that holds all indexes where more water than
             # in the required threshold is collected. (acc >= threshold)

--- a/src/topotoolbox/stream_object.py
+++ b/src/topotoolbox/stream_object.py
@@ -141,7 +141,7 @@ class StreamObject():
 
             # Generate the flow accumulation matrix (acc)
             acc = np.zeros(flow.shape, order='F', dtype=np.float32)
-            fraction = np.zeros_like(flow.source, dtype=np.float32)
+            fraction = np.ones_like(flow.source, dtype=np.float32)
             weights = np.ones(flow.shape, order='F', dtype=np.float32)
             _flow.flow_accumulation(
                 acc, flow.source, flow.target, fraction, weights, flow.shape)

--- a/src/topotoolbox/stream_object.py
+++ b/src/topotoolbox/stream_object.py
@@ -155,13 +155,11 @@ class StreamObject():
         self.stream = np.nonzero(w)[0]
 
         # Find edges whose source pixel is in the stream network
-        u = flow.source.ravel(order='F')
-        v = flow.target.ravel(order='F')
+        u = flow.source
+        v = flow.target
         d = flow.direction.ravel(order='F')
 
-        # v = -1 when the pixel is a sink or outlet. Drop those edges
-        # from the flow network
-        i = w[u] & (v != -1)
+        i = w[u]
 
         # Renumber the nodes of the stream network
         ix = np.zeros_like(w,dtype='int64')
@@ -176,7 +174,7 @@ class StreamObject():
         # or FlowObject, use stream[source] or stream[target].
         self.source = ix[u[i]]
         self.target = ix[v[i]]
-        self.direction = d[i]
+        self.direction = d[u[i]]
 
         # misc
         self.path = flow.path

--- a/tests/test_flow_object.py
+++ b/tests/test_flow_object.py
@@ -17,7 +17,7 @@ def test_flowobject(wide_dem):
     assert np.all((0 <= fd.target) & (fd.target < np.prod(dem.shape)))
 
     # Run flow_accumulation at least once during the tests
-    acc = fd.flow_accumulation();
+    acc = fd.flow_accumulation()
 
     # Ensure that FlowObject does not modify the original DEM
     assert np.all(dem.z == original_dem)

--- a/tests/test_flow_object.py
+++ b/tests/test_flow_object.py
@@ -12,6 +12,10 @@ def test_flowobject(wide_dem):
     original_dem = dem.z.copy()
     fd = topo.FlowObject(dem);
 
+    # Ensure that the source and target arrays contain valid pixel indices
+    assert np.all((0 <= fd.source) & (fd.source < np.prod(dem.shape)))
+    assert np.all((0 <= fd.target) & (fd.target < np.prod(dem.shape)))
+
     # Run flow_accumulation at least once during the tests
     acc = fd.flow_accumulation();
 


### PR DESCRIPTION
This should resolve #146. It required changing `flow_routing_targets` to `flow_routing_d8_edgelist` as expected, but it also required us to switch from using libtopotoolbox's `flow_accumulation` to `flow_accumulation_edgelist`. I had hoped to make this switch otherwise, so this was a good opportunity to do it. There was one other minor libtopotoolbox change to `drainagebasins` that this effort revealed (TopoToolbox/libtopotoolbox#169).

The changes to StreamObject were minimal, updating it to use the new flow accumulation interface and cleaning up some indices in the constructor function. The normal StreamObject functions already use proper edge lists, so once the constructor was fixed, everything worked properly.

The tests did catch a lot of the necessary changes. I added an index check to `test_flow_object.py` make sure that we don't include the -1 edges in the `FlowObject` edge list.

@Teschl: I don't think this will affect anything you have been currently working on (like #113), but take a look and let me know if anything seems off. As I said, the `StreamObject` internals should remain similar to what it was before because we were already creating and using the edge lists properly. It's really the `FlowObject` that has changed.