### PR TITLE
Add plotdz to StreamObject

### DIFF
--- a/docs/tutorial/stream.ipynb
+++ b/docs/tutorial/stream.ipynb
@@ -48,6 +48,27 @@
     "dem.plot(ax,cmap=\"terrain\")\n",
     "s.plot(ax=ax,color='k');"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "69dd7eb3-8b02-4e75-9a42-c9baa27a58b5",
+   "metadata": {},
+   "source": [
+    "## Plot the longitudinal stream profile\n",
+    "\n",
+    "Applications in tectonic geomorphology are often interested in longitudinal profiles and features such as knickpoints. Visual inspection of the profile provides a first clue for these features."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5d3aa720-a5cd-4b5d-8adc-2851c966ca4b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ax = s.plotdz(dem)\n",
+    "ax.autoscale_view()"
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
Resolves #114

This was fairly straightforward to implement using the same pattern as normally plotting a StreamObject with a LineCollection. A small modification to `StreamObject.xy` allows a user to pass a tuple of x, and y node attribute lists that are segmented as appropriate. The segmentation is separate from the values of the generated points. If no data are passed it, the previous behavior, which returns the x and y indices of the pixels in the GridObject is preserved.

We use libtopotoolbox's `streamquad_trapz_f32` to compute upstream distance though there are simpler ways to do so with other traversal methods, and we should change that once such traversals are available in libtopotoolbox.

The optional arguments supported by MATLAB's plotdz are not all supported yet. Passing `linewidths` as a keyword argument will work, because this is forwarded to the underlying LineCollection. `dunit` and `doffset` should be relatively straightforward to add. Plotting multicolored line segments with LineCollection is possible, but rather complicated, and I have not yet figured out a good way to handle this.