### PR TITLE
docs: Use nearest-neighbor interpolation with discrete data

### DIFF
--- a/docs/tutorial/flow.ipynb
+++ b/docs/tutorial/flow.ipynb
@@ -57,7 +57,7 @@
    "source": [
     "## Drainage basin delineation\n",
     "\n",
-    "Catchments can be derived using the function `drainagebasins`. The function returns a `GridObject` with integer values (a label grid). To make it easier to visualize the catchments, one can randomize the labels of the grid with `shufflelabel`."
+    "Catchments can be derived using the function `drainagebasins`. The function returns a `GridObject` with integer values (a label grid). To make it easier to visualize the catchments, one can randomize the labels of the grid with `shufflelabel`. Drainage basins are labeled with discrete indices, and it is often a good idea to use nearest-neighbor interpolation when visualizing a discrete `GridObject` to avoid smearing of the boundaries between drainage basins."
    ]
   },
   {
@@ -68,7 +68,7 @@
    "outputs": [],
    "source": [
     "D = fd.drainagebasins()\n",
-    "D.shufflelabel().plot(cmap=\"Pastel1\")"
+    "D.shufflelabel().plot(cmap=\"Pastel1\",interpolation=\"nearest\")"
    ]
   }
  ],


### PR DESCRIPTION
This prevents a visible artifact of smoothing along the boundaries between drainage basins.