### PR TITLE
Add trunk to the Getting Started Guide

### DIFF
--- a/docs/tutorial/stream.ipynb
+++ b/docs/tutorial/stream.ipynb
@@ -51,6 +51,30 @@
   },
   {
    "cell_type": "markdown",
+   "id": "59d018e0-d5c0-4fe4-a440-1c0cf2ea777b",
+   "metadata": {},
+   "source": [
+    "## Modify the stream network\n",
+    "\n",
+    "Frequently, we might be only interested in parts of the river network. For example, we can extract the trunk of each drainage basin using the `trunk` method on `StreamObject`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "31bb9cab-6c34-48b1-9e64-0159efa78b8b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "t = s.trunk()\n",
+    "fig,ax = plt.subplots()\n",
+    "dem.plot(ax=ax,cmap=\"terrain\")\n",
+    "s.plot(ax=ax, color='k')\n",
+    "t.plot(ax=ax, color='r')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "69dd7eb3-8b02-4e75-9a42-c9baa27a58b5",
    "metadata": {},
    "source": [
@@ -68,9 +92,17 @@
    "source": [
     "fig = plt.figure()\n",
     "ax = plt.axes(xlabel=\"Distance (km)\", ylabel=\"Elevation (m)\")\n",
-    "s.plotdz(dem, ax=ax, dunit='km')\n",
+    "t.plotdz(dem, ax=ax, dunit='km')\n",
     "ax.autoscale_view()"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "46c96f6e-f5e5-4de9-aff7-3d33f5f6e005",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
The new section of docs/tutorial/stream.ipynb, "Modify the stream network", is not yet identical to the MATLAB Getting Started Guide because we still need `klargestconncomps` (#112), but it can now plot the trunk stream in each drainage basin using `StreamObject.trunk` (#153).