### PR TITLE
Implement klargestconncomps

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ include(FetchContent)
 FetchContent_Declare(
   topotoolbox
   GIT_REPOSITORY https://github.com/TopoToolbox/libtopotoolbox.git
-  GIT_TAG 3458418513a5a92061c18a12bc02659de9ef1667
+  GIT_TAG 82c5981a1ebd4a249efaeba508a2b8556b51c3af
 )
 FetchContent_MakeAvailable(topotoolbox)
 

--- a/src/lib/stream.cpp
+++ b/src/lib/stream.cpp
@@ -83,9 +83,53 @@ void wrap_traverse_down_f32_max_add(py::array_t<float> output,
                             target_ptr, edge_count);
 }
 
+void wrap_traverse_down_f32_add_mul(py::array_t<float> output,
+                                    py::array_t<float> input,
+                                    py::array_t<ptrdiff_t> source,
+                                    py::array_t<ptrdiff_t> target) {
+  float *output_ptr = output.mutable_data();
+  float *input_ptr = input.mutable_data();
+  ptrdiff_t *source_ptr = source.mutable_data();
+  ptrdiff_t *target_ptr = target.mutable_data();
+
+  ptrdiff_t edge_count = source.size();
+
+  traverse_down_f32_add_mul(output_ptr, input_ptr, source_ptr,
+                            target_ptr, edge_count);
+}
+
+void wrap_edgelist_degree(py::array_t<uint8_t> indegree,
+                          py::array_t<uint8_t> outdegree,
+                          py::array_t<ptrdiff_t> source,
+                          py::array_t<ptrdiff_t> target) {
+  uint8_t *indegree_ptr = indegree.mutable_data();
+  uint8_t *outdegree_ptr = outdegree.mutable_data();
+  ptrdiff_t *source_ptr = source.mutable_data();
+  ptrdiff_t *target_ptr = target.mutable_data();
+
+  ptrdiff_t node_count = indegree.size();
+  ptrdiff_t edge_count = source.size();
+
+  edgelist_degree(indegree_ptr, outdegree_ptr, source_ptr,
+                  target_ptr, node_count, edge_count);
+}
+
+void wrap_propagatevaluesupstream_u8(py::array_t<uint8_t> data,
+                                     py::array_t<ptrdiff_t> source,
+                                     py::array_t<ptrdiff_t> target) {
+
+  propagatevaluesupstream_u8(data.mutable_data(),
+                             source.mutable_data(),
+                             target.mutable_data(),
+                             source.size());
+}
+
 PYBIND11_MODULE(_stream, m) {
   m.def("streamquad_trapz_f32", &wrap_streamquad_trapz_f32);
   m.def("streamquad_trapz_f64", &wrap_streamquad_trapz_f64);
   m.def("traverse_up_u32_and", &wrap_traverse_up_u32_and);
-  m.def("traverse_down_f32_max_add", &wrap_traverse_down_f32_max_add);  
+  m.def("traverse_down_f32_max_add", &wrap_traverse_down_f32_max_add);
+  m.def("traverse_down_f32_add_mul", &wrap_traverse_down_f32_add_mul);
+  m.def("edgelist_degree", &wrap_edgelist_degree);
+  m.def("propagatevaluesupstream_u8", &wrap_propagatevaluesupstream_u8);
 }

--- a/tests/test_stream_object.py
+++ b/tests/test_stream_object.py
@@ -4,6 +4,12 @@ import numpy as np
 
 import topotoolbox as topo
 
+def issubgraph(S1 : topo.StreamObject, S2 : topo.StreamObject):
+    """Test whether S1 represents a subgraph of S2
+    """
+    es1 = set(map(tuple,np.stack((S1.stream[S1.source],S1.stream[S1.target]),axis=1)))
+    es2 = set(map(tuple,np.stack((S2.stream[S2.source],S2.stream[S2.target]),axis=1)))
+    return es1 <= es2
 
 @pytest.fixture
 def wide_dem():
@@ -35,6 +41,14 @@ def test_init(tall_dem, wide_dem):
     # Run the chi transforms
     tall_stream.chitransform(tall_acc)
     wide_stream.chitransform(wide_acc)
+
+    tall_trunk = tall_stream.trunk()
+    tall_k1    = tall_stream.klargestconncomps(1)
+    tall_k1_trunk = tall_k1.trunk()
+
+    assert issubgraph(tall_trunk, tall_stream)
+    assert issubgraph(tall_k1, tall_stream)
+    assert not issubgraph(tall_trunk, tall_k1)
 
     grid_obj = topo.gen_random(rows=64, columns=64)
     flow_obj = topo.FlowObject(grid_obj)


### PR DESCRIPTION
This version of `klargestconncomps` uses traversals implemented in libtopotoolbox to compute the size of each connected component of the stream network and to propagate the identities of the largest connected components upstream.

test/stream_object.py adds some tests that ensure that `trunk` and `klargestconncomps` create subgraphs of the original stream network. A helper function `issubgraph` could also be included in the `StreamObject` interface, but it is not particularly efficient as it relies on set operations.