### PR TITLE
Fix numbering of rows and columns in the StreamObject tests

### DIFF
--- a/tests/test_stream_object.py
+++ b/tests/test_stream_object.py
@@ -13,11 +13,11 @@ def issubgraph(S1 : topo.StreamObject, S2 : topo.StreamObject):
 
 @pytest.fixture
 def wide_dem():
-    yield topo.gen_random(rows=128, columns=64)
+    yield topo.gen_random(rows=64, columns=128)
 
 @pytest.fixture
 def tall_dem():
-    yield topo.gen_random(columns=64, rows=128)
+    yield topo.gen_random(rows=128, columns=64)
 
 def test_init(tall_dem, wide_dem):
     tall_flow = topo.FlowObject(tall_dem)


### PR DESCRIPTION
The tall and wide DEMs previously ended up being the same size because the argument order was switched rather than switching the argument values.