### PR TITLE
Remove unused tests/test_utils.py and tests/__init__.py

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,2 +1,0 @@
-import pytest
-import topotoolbox.utils


### PR DESCRIPTION
@Teschl: these files don't seem to do anything. Is there a reason to keep them around? I gather [from here](https://docs.pytest.org/en/stable/explanation/goodpractices.html) that there are circumstances when you might need an `__init__.py` in the `tests/` directory, but it does not seem like that advice applies to us at the moment.