### PR TITLE
Add hillshade to GridObject

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ include(FetchContent)
 FetchContent_Declare(
   topotoolbox
   GIT_REPOSITORY https://github.com/TopoToolbox/libtopotoolbox.git
-  GIT_TAG 7731ce8fe21d4c5a23e7fbaacdc102b1550cdf68
+  GIT_TAG ebe13075246a2a3fd0d42111703bda4cc5c3a5d7
 )
 FetchContent_MakeAvailable(topotoolbox)
 

--- a/src/lib/grid.cpp
+++ b/src/lib/grid.cpp
@@ -246,6 +246,24 @@ void wrap_gradient8(
     gradient8(output_ptr, dem_ptr, cellsize, use_mp, dims_ptr);
 }
 
+void wrap_hillshade(py::array_t<float> output,
+                    py::array_t<float>nx, py::array_t<float> ny, py::array_t<float> nz,
+                    py::array_t<float> dem,
+                    float azimuth, float altitude, float cellsize,
+                    std::tuple<ptrdiff_t, ptrdiff_t> dims) {
+  
+  float *output_ptr = output.mutable_data();
+  float *nx_ptr = nx.mutable_data();
+  float *ny_ptr = ny.mutable_data();
+  float *nz_ptr = nz.mutable_data();
+  float *dem_ptr = dem.mutable_data();
+
+  std::array<ptrdiff_t, 2> dims_array = {std::get<0>(dims), std::get<1>(dims)};
+  hillshade(output_ptr, nx_ptr, ny_ptr, nz_ptr,
+            dem_ptr, azimuth, altitude, cellsize,
+            dims_array.data());
+}
+
 // Make wrap_funcname() function available as funcname() to be used by
 // by functions in the pytopotoolbox package
 
@@ -260,4 +278,5 @@ PYBIND11_MODULE(_grid, m) {
     m.def("flow_routing_d8_carve", &wrap_flow_routing_d8_carve);
     m.def("flow_routing_d8_edgelist", &wrap_flow_routing_d8_edgelist);
     m.def("gradient8", &wrap_gradient8);
+    m.def("hillshade", &wrap_hillshade);
 }


### PR DESCRIPTION
Resolves #131 

This adds a wrapper for the libtopotoolbox hillshade function and a method to GridObject that calls that wrapper. The procedure for converting the azimuth angle from a geographic bearing into the grid's coordinate system is rather involved, but it seems to work for our example DEMs. A test is added that compares the hillshades of random DEMs in row- and column-major order to test that this azimuth angle computation is correct. Some comments are added to help explain the process of rotating the azimuth angle.

Note that `GridObject.hillshade` only computes the hillshade, it does not display it. This behaves differently from TopoToolbox v2, but a separate plotting function or a `hillshade` argument to `GridObject.plot` fits more naturally with our existing visualization API.