### PR TITLE
Add a plot_hs method to GridObject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,4 +55,5 @@ disable = [
     "cyclic-import",
     "too-many-positional-arguments",
     "too-many-lines",
+    "too-many-public-methods",
 ]


### PR DESCRIPTION
This method computes a hillshade using the recently added `hillshade` method and then blends it with an RGB image represented the colorized data. This manually implements a lot of what matplotlib provides in its colors.LightSource module. However, the most complicated part is computing the hillshade, which we already do through libtopotoolbox. On the other hand, much of the complexity of MATLAB's imageschs function lies in sorting out the colormaps, which we pass off to matplotlib through its usual normalization->colormap pipeline.

The "overlay" and "soft" blend modes are provided by matplotlib, so it seemed reasonable to include them. The "multiply" blend mode is similar to what MATLAB TopoToolbox uses for its hillshading.

I have also included some options to filter the DEM before hillshading using our `filter` method. This helps improve the visualization quality at large scale or low resolutions.

This is the 21st public method for `GridObject`, which means we hit another pylint warning about having too many public methods. I turned it off for now, but this is further encouragement to remove some of these functions (see #120).