### PR TITLE
Only run the release workflow on the main TopoToolbox repository

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   make_sdist:
+    if: github.repository == 'TopoToolbox/pytopotoolbox'
     name: Make SDist
     runs-on: ubuntu-latest
     steps:
@@ -23,6 +24,7 @@ jobs:
           name: cibw-sdist
           path: dist/*.tar.gz
   build_wheels:
+    if: github.repository == 'TopoToolbox/pytopotoolbox'
     name: Wheel on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
@@ -53,6 +55,7 @@ jobs:
           name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}
           path: ./wheelhouse/*.whl
   upload_assets:
+    if: github.repository == 'TopoToolbox/pytopotoolbox'
     name: Upload release assets
     needs: [build_wheels, make_sdist]
     runs-on: ubuntu-latest
@@ -70,6 +73,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ github.event.release.tag_name }}
   upload-pypi:
+    if: github.repository == 'TopoToolbox/pytopotoolbox'
     name: Upload release assets to PyPI
     needs: [build_wheels, make_sdist]
     runs-on: ubuntu-latest


### PR DESCRIPTION
All of the jobs in the release workflow now check that they are running from within the TopoToolbox/pytopotoolbox repository and will not run on forks. Because the job had to be triggered by a release, and because our PyPI trusted publishing setup should only work from the TopoToolbox repository, I think this is not entirely necessary, but I have made the same change to the release workflows in topotoolbox3 and libtopotoolbox.