### PR TITLE
Use bool as the data type of the visited array

### DIFF
--- a/src/topotoolbox/stream_object.py
+++ b/src/topotoolbox/stream_object.py
@@ -301,7 +301,7 @@ class StreamObject():
             adjacency_list[src].append(tgt)
 
         # Depth-first search of the graph
-        visited = np.zeros(self.stream.size, dtype=np.bool)
+        visited = np.zeros(self.stream.size, dtype=bool)
         segments = []
         stack = []
 


### PR DESCRIPTION
This is to avoid compatibility problems related to the temporary deprecation of `np.bool` from numpy v1.20.0.