### PR TITLE
Add the upgrade flag to the docs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -12,7 +12,7 @@ TopoToolbox is on PyPI, so you can run
 
 .. code-block:: bash
 
-    pip install topotoolbox
+    pip install --upgrade topotoolbox
 
 to obtain the latest version.
 


### PR DESCRIPTION
If an older version of topotoolbox is installed, this should download and install a newer one.