### PR TITLE
Use arctan2 instead of atan2

### DIFF
--- a/src/topotoolbox/grid_object.py
+++ b/src/topotoolbox/grid_object.py
@@ -849,7 +849,7 @@ class GridObject():
         dx, dy = ~gt * (sx, sy)
 
         # And retrieve the azimuth angle.
-        azimuth_radians = np.atan2(dy,dx)
+        azimuth_radians = np.arctan2(dy,dx)
 
         # NOTE(wkearn): This angle is then immediately used within
         # hillshade to compute vector components again. It would be


### PR DESCRIPTION
np.atan2 was introduced in v2.0.0 as an alias of np.arctan2, so if we want to remain compatible with older versions of numpy, we need to use the older function.