### PR TITLE
Fix a minimum supported numpy version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pytest
+          pip install pytest build
 
       - name: Build and install TopoToolbox
         run: |
@@ -42,6 +42,7 @@ jobs:
       - name: Test against oldest supported numpy version
         run: |
           pip install numpy==1.23.5
+          python -m pytest
   lint:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Downgrade numpy
         run: |
-          pip install matplotlib scipy rasterio numpy==1.23.5 --upgrade --upgrade-strategy eager
+          pip install matplotlib scipy rasterio "numpy<1.23" --upgrade --upgrade-strategy eager
           pytest
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Downgrade numpy
         run: |
-          pip install numpy==1.24
+          pip install matplotlib scipy rasterio numpy==1.23.5 --upgrade --upgrade-strategy eager
           pytest
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Downgrade numpy
         run: |
-          pip install matplotlib scipy rasterio "numpy<1.23" --upgrade --upgrade-strategy eager
+          pip install matplotlib scipy rasterio "numpy==1.23.5" --upgrade --upgrade-strategy eager
           pytest
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,15 +34,10 @@ jobs:
         run: |
           python -m pytest
 
-      - name: Build wheel and install it
+      - name: Downgrade numpy
         run: |
-          python -m build
-          pip install dist/*.whl
-          
-      - name: Test against oldest supported numpy version
-        run: |
-          pip install numpy==1.23.5
-          python -m pytest
+          pip install numpy==1.24
+          pytest
   lint:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,7 +2,7 @@ name: CI
 on:
   pull_request:    
   push:
-    branches: ["main"]
+    branches: ["ci-older-numpy"]
 jobs:
   build-and-test:
     runs-on: ${{ matrix.os }}
@@ -34,6 +34,14 @@ jobs:
         run: |
           python -m pytest
 
+      - name: Build wheel and install it
+        run: |
+          python -m build
+          pip install dist/*.whl
+          
+      - name: Test against oldest supported numpy version
+        run: |
+          pip install numpy==1.23.5
   lint:
     runs-on: ubuntu-latest
     strategy:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ description = "Python interface to TopoToolbox."
 readme = "README.md"
 license = { file = "LICENSE" }
 dependencies = [
-    "numpy",
+    "numpy>=1.23.5",
     "matplotlib",
     "scipy",
     "rasterio"


### PR DESCRIPTION
Some tests have suggested that numpy>=1.23.5 will successfully build on all of our platforms with the changes in #169 and #171. This PR fixes that version in pyproject.toml and reruns the tests on CI using this older version.

Closes #172 