### PR TITLE
Initialize StreamObjects from channel heads

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ include(FetchContent)
 FetchContent_Declare(
   topotoolbox
   GIT_REPOSITORY https://github.com/TopoToolbox/libtopotoolbox.git
-  GIT_TAG 827b735e2c4b734d7ed3b00421f4266567db37b9
+  GIT_TAG f20d66f8509eab02cc062e95ddd1ef1dbd233324
 )
 FetchContent_MakeAvailable(topotoolbox)
 

--- a/src/lib/stream.cpp
+++ b/src/lib/stream.cpp
@@ -67,6 +67,22 @@ void wrap_traverse_up_u32_and(py::array_t<uint32_t> output,
                       target_ptr, edge_count);  
 }
 
+void wrap_traverse_down_u32_or_and(py::array_t<uint32_t> output,
+                                   py::array_t<uint32_t> input,
+                                   py::array_t<ptrdiff_t> source,
+                                   py::array_t<ptrdiff_t> target) {
+
+  uint32_t *output_ptr = output.mutable_data();
+  uint32_t *input_ptr = input.mutable_data();
+  ptrdiff_t *source_ptr = source.mutable_data();
+  ptrdiff_t *target_ptr = target.mutable_data();
+
+  ptrdiff_t edge_count = source.size(); 
+
+  traverse_down_u32_or_and(output_ptr, input_ptr, source_ptr,
+                           target_ptr, edge_count);  
+}
+
 void wrap_traverse_down_f32_max_add(py::array_t<float> output,
                                     py::array_t<float> input,
                                     py::array_t<ptrdiff_t> source,
@@ -128,6 +144,7 @@ PYBIND11_MODULE(_stream, m) {
   m.def("streamquad_trapz_f32", &wrap_streamquad_trapz_f32);
   m.def("streamquad_trapz_f64", &wrap_streamquad_trapz_f64);
   m.def("traverse_up_u32_and", &wrap_traverse_up_u32_and);
+  m.def("traverse_down_u32_or_and", &wrap_traverse_down_u32_or_and);
   m.def("traverse_down_f32_max_add", &wrap_traverse_down_f32_max_add);
   m.def("traverse_down_f32_add_mul", &wrap_traverse_down_f32_add_mul);
   m.def("edgelist_degree", &wrap_edgelist_degree);

--- a/tests/test_stream_object.py
+++ b/tests/test_stream_object.py
@@ -121,3 +121,32 @@ def test_stream_subgraphs(tall_dem, wide_dem):
 
     assert not issubgraph(wide_trunk, tall_stream)
     assert not issubgraph(tall_trunk, wide_stream)
+
+def test_stream_channelheads(tall_dem, wide_dem):
+    fd = topo.FlowObject(tall_dem)
+    s = topo.StreamObject(fd)
+
+    indegree = np.zeros(s.stream.size, dtype=np.uint8)
+    outdegree = np.zeros(s.stream.size, dtype=np.uint8)
+    topo._stream.edgelist_degree(indegree, outdegree, s.source, s.target)
+    channel_heads = (outdegree > 0) & (indegree == 0)
+
+    s2 = topo.StreamObject(fd, channelheads=s.stream[channel_heads])
+
+    assert np.array_equal(s2.stream[s2.source], s.stream[s.source])
+    assert np.array_equal(s2.stream[s2.target], s.stream[s.target])
+
+    fd = topo.FlowObject(wide_dem)
+    s = topo.StreamObject(fd)
+
+    indegree = np.zeros(s.stream.size, dtype=np.uint8)
+    outdegree = np.zeros(s.stream.size, dtype=np.uint8)
+    topo._stream.edgelist_degree(indegree, outdegree, s.source, s.target)
+    channel_heads = (outdegree > 0) & (indegree == 0)
+
+    s2 = topo.StreamObject(fd, channelheads=s.stream[channel_heads])
+
+    assert np.array_equal(s2.stream[s2.source], s.stream[s.source])
+    assert np.array_equal(s2.stream[s2.target], s.stream[s.target])
+
+    


### PR DESCRIPTION
Resolves https://github.com/TopoToolbox/pytopotoolbox/issues/183

This uses a downstream flow traversal to compute the influence map of
the supplied pixels and then uses the influence map to pick out the
stream locations.