### PR TITLE
Identify outlets and channelheads with streampoi

### DIFF
--- a/src/topotoolbox/stream_object.py
+++ b/src/topotoolbox/stream_object.py
@@ -275,6 +275,38 @@ class StreamObject():
 
         return nal
 
+    def streampoi(self, point_type: str):
+        """Extract points of interest from the stream network
+
+        Currently supported points of interest are 'channelheads' or 'outlets'
+
+        Parameters
+        ----------
+        point_type: 'channelheads' or 'outlets'
+            The type of points to select from the stream network
+
+        Returns
+        -------
+        np.ndarray
+            A logical node attribute list indicating the locations of points.
+
+        Raises
+        ------
+        ValueError
+            If an unknown point type is requested.
+        """
+        indegree = np.zeros(self.stream.size, dtype=np.uint8)
+        outdegree = np.zeros(self.stream.size, dtype=np.uint8)
+        _stream.edgelist_degree(indegree, outdegree, self.source, self.target)
+        if point_type == 'channelheads':
+            output = (outdegree > 0) & (indegree == 0)
+        elif point_type == 'outlets':
+            output = (outdegree == 0) & (indegree > 0)
+        else:
+            raise ValueError(f"{point_type} is not currently supported")
+
+        return output
+
     def xy(self, data=None):
         """Compute the x and y coordinates of continuous stream segments
 

--- a/tests/test_stream_object.py
+++ b/tests/test_stream_object.py
@@ -126,10 +126,7 @@ def test_stream_channelheads(tall_dem, wide_dem):
     fd = topo.FlowObject(tall_dem)
     s = topo.StreamObject(fd)
 
-    indegree = np.zeros(s.stream.size, dtype=np.uint8)
-    outdegree = np.zeros(s.stream.size, dtype=np.uint8)
-    topo._stream.edgelist_degree(indegree, outdegree, s.source, s.target)
-    channel_heads = (outdegree > 0) & (indegree == 0)
+    channel_heads = s.streampoi("channelheads")
 
     s2 = topo.StreamObject(fd, channelheads=s.stream[channel_heads])
 
@@ -139,14 +136,9 @@ def test_stream_channelheads(tall_dem, wide_dem):
     fd = topo.FlowObject(wide_dem)
     s = topo.StreamObject(fd)
 
-    indegree = np.zeros(s.stream.size, dtype=np.uint8)
-    outdegree = np.zeros(s.stream.size, dtype=np.uint8)
-    topo._stream.edgelist_degree(indegree, outdegree, s.source, s.target)
-    channel_heads = (outdegree > 0) & (indegree == 0)
+    channel_heads = s.streampoi("channelheads")
 
     s2 = topo.StreamObject(fd, channelheads=s.stream[channel_heads])
 
     assert np.array_equal(s2.stream[s2.source], s.stream[s.source])
     assert np.array_equal(s2.stream[s2.target], s.stream[s.target])
-
-    


### PR DESCRIPTION
Implements part of #182

s.streampoi("channelheads") or s.streampoi("outlets") will provide a logical node attribute list identifying locations of the channel heads or outlets.

The channelheads initializer tests are converted to use `streampoi`.