### PR TITLE
Implement `FlowObject.flowpathextract` in the downstream direction

### DIFF
--- a/src/topotoolbox/flow_object.py
+++ b/src/topotoolbox/flow_object.py
@@ -5,6 +5,7 @@ import numpy as np
 # pylint: disable=no-name-in-module
 from . import _grid  # type: ignore
 from . import _flow  # type: ignore
+from . import _stream  # type: ignore
 from .grid_object import GridObject
 
 __all__ = ['FlowObject']
@@ -194,6 +195,30 @@ class FlowObject():
         result.crs = self.crs
 
         return result
+
+    def flowpathextract(self, idx: int):
+        """Extract linear indices of a single flowpath in a DEM
+
+        The flow path downstream of idx is extracted from the flow
+        directions recorded in FlowObject.
+
+        Parameters
+        ----------
+        idx: int
+            The column-major linear index of the starting pixel of the flowpath.
+
+        Returns
+        -------
+        np.ndarray        
+            An array containing column-major linear indices into the
+            DEM identifying the flow path.
+        """
+        ch = np.zeros(self.shape,dtype=np.uint32,order='F')
+        ch[np.unravel_index(idx, self.shape, order='F')] = 1
+        edges = np.ones(self.source.size, dtype=np.uint32)
+        _stream.traverse_down_u32_or_and(ch, edges, self.source, self.target)
+
+        return np.nonzero(np.ravel(ch,order='F'))[0]
 
     # 'Magic' functions:
     # ------------------------------------------------------------------------

--- a/tests/test_flow_object.py
+++ b/tests/test_flow_object.py
@@ -22,3 +22,13 @@ def test_flowobject(wide_dem):
     # Ensure that FlowObject does not modify the original DEM
     assert np.all(dem.z == original_dem)
 
+def test_flowpathextract(wide_dem):
+    fd = topo.FlowObject(wide_dem)
+    s = topo.StreamObject(fd)
+    ch = s.streampoi('channelheads')
+
+    s2 = topo.StreamObject(fd, channelheads=s.stream[ch][0:1])
+
+    idxs = fd.flowpathextract(s.stream[ch][0])
+    assert np.array_equal(s2.stream, idxs)
+


### PR DESCRIPTION
See #189

A new method is added to FlowObject in src/topotoolbox/flow_object.py that computes the indices of a flow path in the downstream direction using the downstream Boolean semiring traversal followed by some index extraction.

A test is added to tests/test_flow_object.py that ensures that the flow path extracted here is identical to the StreamObject constructed using the `channelheads` argument.