### PR TITLE
Plot GridObjects and StreamObjects with coordinates

### DIFF
--- a/src/topotoolbox/grid_object.py
+++ b/src/topotoolbox/grid_object.py
@@ -81,6 +81,17 @@ class GridObject():
         raise TypeError(
             "Grid is not stored as a contiguous row- or column-major array")
 
+    @property
+    def extent(self):
+        """The bounding box of the grid in the order needed for plotting
+
+        Returns
+        -------
+        tuple
+            The bounding box in the order (left, right, bottom, top)
+        """
+        return (self.bounds.left, self.bounds.right, self.bounds.bottom, self.bounds.top)
+
     def reproject(self,
                   crs: 'CRS',
                   resolution: 'float | None' = None,
@@ -974,7 +985,7 @@ class GridObject():
         print(f"maximum z-value: {np.nanmax(self.z)}")
         print(f"minimum z-value: {np.nanmin(self.z)}")
 
-    def plot(self, ax=None, **kwargs):
+    def plot(self, ax=None, extent=None, **kwargs):
         """Plot the GridObject
 
         Parameters
@@ -982,6 +993,11 @@ class GridObject():
         ax: matplotlib.axes.Axes, optional
             The axes in which to plot the GridObject. If no axes
             are given, the current axes are used.
+
+        extent: floats (left, right, bottom, top), optional        
+            The bounding box used to set the axis limits. If no extent
+            is supplied, defaults to self.extent, which plots the
+            GridObject in geographic coordinates.
 
         **kwargs
             Additional keyword arguments are forwarded to
@@ -991,10 +1007,15 @@ class GridObject():
         -------
         matplotlib.image.AxesImage
             The image constructed by imshow
+
         """
         if ax is None:
             ax = plt.gca()
-        return ax.imshow(self.z, **kwargs)
+
+        if extent is None:
+            extent = self.extent
+
+        return ax.imshow(self.z, extent=extent, **kwargs)
 
     def plot_hs(self, ax=None,
                 elev=None,
@@ -1002,6 +1023,7 @@ class GridObject():
                 filter_method=None, filter_size = 3,
                 cmap='terrain', norm = None,
                 blend_mode='soft',
+                extent=None,
                 **kwargs):
         """Plot a shaded relief map of the GridObject
 
@@ -1040,6 +1062,9 @@ class GridObject():
         blend_mode: {'multiply', 'overlay', 'soft'}, optional
             The algorithm used to combine the shaded elevation with
             the data. Defaults to 'soft'.
+       extent: floats (left, right, bottom, top), optional        
+            The bounding box used to set the axis limits. If no extent
+            is supplied, defaults to self.extent
         **kwargs
             Additional keyword arguments are forwarded to
             matplotlib.axes.Axes.imshow
@@ -1099,7 +1124,10 @@ class GridObject():
         else:
             raise ValueError("blend_mode not supported") from None
 
-        return ax.imshow(np.clip(rgb,0,1), **kwargs)
+        if extent is None:
+            extent = self.extent
+
+        return ax.imshow(np.clip(rgb,0,1), extent=extent, **kwargs)
 
     def shufflelabel(self, seed=None):
         """Randomize the labels of a GridObject

--- a/src/topotoolbox/stream_object.py
+++ b/src/topotoolbox/stream_object.py
@@ -319,11 +319,7 @@ class StreamObject():
            A tuple of two node attribute lists representing the
            desired x and y values for each pixel in the stream
            network. If this argument is not supplied, the returned x
-           and y values are the indices of the pixel in the DEM in the
-           second and first dimension respectively. This reversal of
-           dimensions corresponds to the orientation used by pyplot's
-           `imshow`, and allows plotting the stream network over a
-           corresponding GridObject.
+           and y values are the geographic coordinates of the node.
 
         Returns
         -------
@@ -333,7 +329,8 @@ class StreamObject():
         """
         if data is None:
             # pylint: disable=unbalanced-tuple-unpacking
-            ys, xs = np.unravel_index(self.stream, self.shape, order='F')
+            j, i = np.unravel_index(self.stream, self.shape, order='F')
+            xs, ys = self.transform * np.vstack((i,j))
         else:
             xs, ys = data
 


### PR DESCRIPTION
Resolves #187

This commit adds an `extent` property to `GridObject`, which constructs a bounding box in the order that matplotlib expects for its `extent` argument to `imshow`. This bounding box is then supplied to `imshow` to plot the `GridObject` with the proper coordinates.

`StreamObject.xy` now defaults to using the geotransform to convert the pixel indices into coordinates. `StreamObject.plot` therefore now plots into the coordinate space. The other use of `StreamObject.xy` in `StreamObject.plotdz` uses the `data` argument to `plotdz`, so it is not affected.