### PR TITLE
Implement imposemin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ include(FetchContent)
 FetchContent_Declare(
   topotoolbox
   GIT_REPOSITORY https://github.com/TopoToolbox/libtopotoolbox.git
-  GIT_TAG f20d66f8509eab02cc062e95ddd1ef1dbd233324
+  GIT_TAG 6b631471b31d1cfef14193087ffe0a7a20bc1bcb
 )
 FetchContent_MakeAvailable(topotoolbox)
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -8,6 +8,7 @@ API Documentation
    topotoolbox.GridObject
    topotoolbox.FlowObject
    topotoolbox.StreamObject
+   topotoolbox.stream_functions
    topotoolbox.run_graphflood
    topotoolbox.read_tif
    topotoolbox.write_tif

--- a/src/lib/stream.cpp
+++ b/src/lib/stream.cpp
@@ -99,6 +99,22 @@ void wrap_traverse_down_f32_max_add(py::array_t<float> output,
                             target_ptr, edge_count);
 }
 
+void wrap_traverse_down_f32_min_add(py::array_t<float> output,
+                                    py::array_t<float> input,
+                                    py::array_t<ptrdiff_t> source,
+                                    py::array_t<ptrdiff_t> target) {
+
+  float *output_ptr = output.mutable_data();
+  float *input_ptr = input.mutable_data();
+  ptrdiff_t *source_ptr = source.mutable_data();
+  ptrdiff_t *target_ptr = target.mutable_data();
+
+  ptrdiff_t edge_count = source.size();
+
+  traverse_down_f32_min_add(output_ptr, input_ptr, source_ptr,
+                            target_ptr, edge_count);
+}
+
 void wrap_traverse_down_f32_add_mul(py::array_t<float> output,
                                     py::array_t<float> input,
                                     py::array_t<ptrdiff_t> source,
@@ -146,6 +162,7 @@ PYBIND11_MODULE(_stream, m) {
   m.def("traverse_up_u32_and", &wrap_traverse_up_u32_and);
   m.def("traverse_down_u32_or_and", &wrap_traverse_down_u32_or_and);
   m.def("traverse_down_f32_max_add", &wrap_traverse_down_f32_max_add);
+  m.def("traverse_down_f32_min_add", &wrap_traverse_down_f32_min_add);
   m.def("traverse_down_f32_add_mul", &wrap_traverse_down_f32_add_mul);
   m.def("edgelist_degree", &wrap_edgelist_degree);
   m.def("propagatevaluesupstream_u8", &wrap_propagatevaluesupstream_u8);

--- a/src/topotoolbox/__init__.py
+++ b/src/topotoolbox/__init__.py
@@ -5,3 +5,4 @@ from .flow_object import FlowObject
 from .stream_object import StreamObject
 from .graphflood import *
 from .utils import *
+from .stream_functions import *

--- a/src/topotoolbox/flow_object.py
+++ b/src/topotoolbox/flow_object.py
@@ -250,6 +250,22 @@ class FlowObject():
 
         return np.nonzero(np.ravel(ch,order='F'))[0]
 
+    def distance(self):
+        """Compute the distance between each node in the flow network
+
+        Returns
+        -------
+        np.ndarray
+            An array (edge attribute list) with the interpixel
+            distance. This will be either cellsize or sqrt(2)*cellsize
+        """
+        d = np.abs(self.source - self.target)
+        dist = self.cellsize * np.where(
+            (d == self.strides[0]) | (d == self.strides[1]),
+            np.float32(1.0),
+            np.sqrt(np.float32(2.0)))
+        return dist
+
     # 'Magic' functions:
     # ------------------------------------------------------------------------
 

--- a/src/topotoolbox/stream_functions.py
+++ b/src/topotoolbox/stream_functions.py
@@ -1,0 +1,72 @@
+"""Functions for working with flow networks
+
+These functions apply to both StreamObjects and FlowObjects
+"""
+import copy
+
+# pylint: disable=no-name-in-module
+from . import _stream  # type: ignore
+
+from .stream_object import StreamObject
+from .flow_object import FlowObject
+from .flow_object import GridObject
+
+def imposemin(s, dem, minimum_slope=0.0):
+    """Minima imposition along a drainage network
+
+    Parameters
+    ----------
+    s : StreamObject | FlowObject
+        The drainage network used to determine flow directions
+
+    dem : GridObject | np.ndarray
+        The elevations to be carved. If s is a FlowObject, this should
+        either be a GridObject or a 2D array of the appropriate
+        shape. If s is a StreamObject, this should be a GridObject or
+        a 2D array of the shape of the DEM from which the StreamObject
+        was derived or a 1D array (a node attribute list) with as many
+        entries as there are nodes in the stream network.
+
+    minimum_slope : float, optional
+        The minimum downward gradient (expressed as a positive
+        nondimensional slope) to be imposed on the
+        elevations. Defaults to zero. Set to a small positive number
+        (e.g. 0.001) to impose a shallow downward slope on the
+        resulting stream profile. Too high a minimum gradient will
+        result in channels that lie well below the land surface.
+
+    Returns
+    -------
+    GridObject | np.ndarray
+        The elevations with the minimum downward gradient imposed. If
+        `dem` is a GridObject, a GridObject is returned. Otherwise an
+        array of the same shape as `dem` is returned.
+
+    Raises
+    ------
+    TypeError
+        If s is neither a FlowObject nor a StreamObject
+    """
+    # We need to pass an array to the libtopotoolbox traversal, but
+    # the return type depends on the types of s and dem, so we need
+    # this slightly complicated arrangement of copies and views to
+    # ensure we fill a new array (not the old one), and can return a
+    # GridObject when necessary.
+    if isinstance(s, StreamObject):
+        result = s.ezgetnal(dem).copy()
+        z = result.view()
+    elif isinstance(s, FlowObject):
+        # TODO(wkearn): check alignment
+        if isinstance(dem, GridObject):
+            result = copy.deepcopy(dem)
+            z = result.z.view()
+        else:
+            result = dem.copy()
+            z = result.view()
+    else:
+        raise TypeError(f"{s} must be either a FlowObject or a StreamObject")
+
+    d = -s.distance() * minimum_slope
+    _stream.traverse_down_f32_min_add(z, d, s.source, s.target)
+
+    return result

--- a/src/topotoolbox/stream_functions.py
+++ b/src/topotoolbox/stream_functions.py
@@ -8,7 +8,6 @@ import numpy as np
 
 # pylint: disable=no-name-in-module
 from . import _stream  # type: ignore
-from . import StreamObject, FlowObject, GridObject
 
 def imposemin(s, dem, minimum_slope=0.0):
     """Minima imposition along a drainage network

--- a/src/topotoolbox/stream_functions.py
+++ b/src/topotoolbox/stream_functions.py
@@ -1,15 +1,12 @@
 """Functions for working with flow networks
 
-These functions apply to both StreamObjects and FlowObjects
+These functions often apply to both StreamObjects and FlowObjects.
 """
 import copy
 
 # pylint: disable=no-name-in-module
 from . import _stream  # type: ignore
-
-from .stream_object import StreamObject
-from .flow_object import FlowObject
-from .flow_object import GridObject
+from . import StreamObject, FlowObject, GridObject
 
 def imposemin(s, dem, minimum_slope=0.0):
     """Minima imposition along a drainage network

--- a/src/topotoolbox/stream_functions.py
+++ b/src/topotoolbox/stream_functions.py
@@ -2,8 +2,6 @@
 
 These functions often apply to both StreamObjects and FlowObjects.
 """
-import copy
-
 import numpy as np
 
 # pylint: disable=no-name-in-module
@@ -23,7 +21,9 @@ def imposemin(s, dem, minimum_slope=0.0):
         shape. If s is a StreamObject, this should be a GridObject or
         a 2D array of the shape of the DEM from which the StreamObject
         was derived or a 1D array (a node attribute list) with as many
-        entries as there are nodes in the stream network.
+        entries as there are nodes in the stream network. The element
+        type of the array can be any numerical type, but it will be
+        converted into float32, so some precision may be lost.
 
     minimum_slope : float, optional
         The minimum downward gradient (expressed as a positive
@@ -37,14 +37,14 @@ def imposemin(s, dem, minimum_slope=0.0):
     -------
     GridObject | np.ndarray
         The elevations with the minimum downward gradient imposed. If
-        `dem` is a GridObject, a GridObject is returned. Otherwise an
-        array of the same shape as `dem` is returned.
-    """
-    result = copy.deepcopy(s.ezgetnal(dem))
+        `dem` is a GridObject, a GridObject is returned. Otherwise a
+        single-precision floating point array of the same shape as
+        `dem` is returned.
 
-    z = np.array(result, dtype=np.float32, copy=False)
+    """
+    result = s.ezgetnal(dem, dtype=np.float32) # This returns a copy
 
     d = -s.distance() * minimum_slope
-    _stream.traverse_down_f32_min_add(z, d, s.source, s.target)
+    _stream.traverse_down_f32_min_add(result, d, s.source, s.target)
 
     return result

--- a/src/topotoolbox/stream_functions.py
+++ b/src/topotoolbox/stream_functions.py
@@ -42,7 +42,7 @@ def imposemin(s, dem, minimum_slope=0.0):
     """
     result = copy.deepcopy(s.ezgetnal(dem))
 
-    z = np.asarray(result, dtype=np.float32, copy=False)
+    z = np.array(result, dtype=np.float32, copy=False)
 
     d = -s.distance() * minimum_slope
     _stream.traverse_down_f32_min_add(z, d, s.source, s.target)

--- a/tests/test_flow_object.py
+++ b/tests/test_flow_object.py
@@ -98,7 +98,7 @@ def test_imposemin_f64(wide_dem):
 
     fd = topo.FlowObject(wide_dem)
 
-    z = np.array(wide_dem, dtype=np.float64)
+    z = np.array(wide_dem.z, dtype=np.float64)
 
     min_dem = topo.imposemin(fd, z, 0.001)
 

--- a/tests/test_flow_object.py
+++ b/tests/test_flow_object.py
@@ -86,3 +86,14 @@ def test_imposemin(wide_dem):
 
         # imposemin should not modify the original array
         assert np.array_equal(original_dem, wide_dem.z)
+
+def test_imposemin_f64(wide_dem):
+    original_dem = np.array(wide_dem, dtype=np.float64)
+
+    fd = topo.FlowObject(wide_dem)
+
+    z = np.array(wide_dem, dtype=np.float64)
+
+    # The np.float64 type is not supported
+    with pytest.raises(ValueError):
+        min_dem = topo.imposemin(fd, z, 0.001)

--- a/tests/test_flow_object.py
+++ b/tests/test_flow_object.py
@@ -1,3 +1,4 @@
+import copy
 import pytest
 
 import numpy as np
@@ -66,3 +67,22 @@ def test_flowpathextract(wide_dem):
     idxs = fd.flowpathextract(s.stream[ch][0])
     assert np.array_equal(s2.stream, idxs)
 
+
+def test_imposemin(wide_dem):
+    original_dem = wide_dem.z.copy()
+    fd = topo.FlowObject(wide_dem)
+
+    for minimum_slope in [0.0,0.001,0.01,0.1]:
+        min_dem = topo.imposemin(fd, wide_dem, minimum_slope)
+
+        # The carved dem should not be above the original
+        assert np.all(min_dem.z <= wide_dem)
+
+        # The gradient along the flow network should be greater than or
+        # equal to the defined slope within some numerical error
+        g = (min_dem.z[np.unravel_index(fd.source,fd.shape,order='F')] -
+             min_dem.z[np.unravel_index(fd.target,fd.shape,order='F')])/fd.distance()
+        assert np.all(g >= minimum_slope - 1e-6)
+
+        # imposemin should not modify the original array
+        assert np.array_equal(original_dem, wide_dem.z)

--- a/tests/test_stream_object.py
+++ b/tests/test_stream_object.py
@@ -273,3 +273,42 @@ def test_stream_channelheads(tall_dem, wide_dem):
 
     assert np.array_equal(s2.stream[s2.source], s.stream[s.source])
     assert np.array_equal(s2.stream[s2.target], s.stream[s.target])
+
+def test_stream_imposemin(tall_dem, wide_dem):
+    fd = topo.FlowObject(tall_dem)
+    s = topo.StreamObject(fd)
+
+    original_z = s.ezgetnal(tall_dem)
+
+    for minimum_slope in [0.0,0.001,0.01,0.1]:
+        minz = topo.imposemin(s, tall_dem, minimum_slope)
+
+        # imposemin should not modify the original array
+        assert np.array_equal(original_z, s.ezgetnal(tall_dem))
+
+        # The carved dem should not be above the original
+        assert np.all(minz <= s.ezgetnal(tall_dem))
+
+        # The gradient along the flow network should be greater than or
+        # equal to the defined slope within some numerical error
+        g = (minz[s.source] - minz[s.target])/s.distance()
+        assert np.all(g >= minimum_slope - 1e-6)
+
+    fd = topo.FlowObject(wide_dem)
+    s = topo.StreamObject(fd)
+
+    original_z = s.ezgetnal(wide_dem)
+
+    for minimum_slope in [0.0,0.001,0.01,0.1]:
+        minz = topo.imposemin(s, wide_dem, minimum_slope)
+
+        # imposemin should not modify the original array
+        assert np.array_equal(original_z, s.ezgetnal(wide_dem))
+
+        # The carved dem should not be above the original
+        assert np.all(minz <= s.ezgetnal(wide_dem))
+
+        # The gradient along the flow network should be greater than or
+        # equal to the defined slope within some numerical error
+        g = (minz[s.source] - minz[s.target])/s.distance()
+        assert np.all(g >= minimum_slope - 1e-6)


### PR DESCRIPTION
`imposemin` can take either a `FlowObject` or a `StreamObject`, so it is implemented as a standalone function in the new file src/topotoolbox/stream_functions.py. It uses the (min,+) traversal recently added to libtopotoolbox.

`imposemin` for a `FlowObject` requires the interpixel distances. I have added a method very similar to `StreamObject.distance` that computes these.

Tests are added for both the `StreamObject` and `FlowObject` versions. The tests ensure:

1. `imposemin` does not modify the original DEM. Certain copies are made explicitly in the implementation of `imposemin` to make sure that this is true.
2. The carved DEM is not above the original
3. The gradient is constrained within numerical error by the `minimum_slope` argument.

@Teschl: would you mind taking a look at this? I've done this one a little differently, using a standalone function in a new submodule instead of implementing separate but identical methods for both `StreamObject` and `FlowObject`, and I want to get some feedback on that approach before merging.