### PR TITLE
Use Big Tujunga DEM in the Getting Started guide

### DIFF
--- a/docs/tutorial/flow.ipynb
+++ b/docs/tutorial/flow.ipynb
@@ -21,7 +21,7 @@
     "import topotoolbox as tt3\n",
     "import matplotlib.pyplot as plt\n",
     "\n",
-    "dem = tt3.load_dem('tibet')\n",
+    "dem = tt3.load_dem('bigtujunga')\n",
     "fd = tt3.FlowObject(dem)"
    ]
   },
@@ -88,7 +88,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.12"
+   "version": "3.11.2"
   }
  },
  "nbformat": 4,

--- a/docs/tutorial/grid.ipynb
+++ b/docs/tutorial/grid.ipynb
@@ -39,7 +39,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dem = tt3.load_dem('tibet')\n",
+    "dem = tt3.load_dem('bigtujunga')\n",
     "g = dem.gradient8()\n",
     "\n",
     "fig0,ax0 = plt.subplots(1,1)\n",
@@ -95,7 +95,13 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "1ea1ac4c-23f1-44ed-9ba7-b6b9366b5ffb",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "fig, (ax1, ax2) = plt.subplots(2,1,layout='constrained')\n",
@@ -125,7 +131,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.12"
+   "version": "3.11.2"
   }
  },
  "nbformat": 4,

--- a/docs/tutorial/stream.ipynb
+++ b/docs/tutorial/stream.ipynb
@@ -22,7 +22,7 @@
     "import topotoolbox as tt3\n",
     "import matplotlib.pyplot as plt\n",
     "\n",
-    "dem = tt3.load_dem('tibet')\n",
+    "dem = tt3.load_dem('bigtujunga')\n",
     "fd  = tt3.FlowObject(dem);\n",
     "s   = tt3.StreamObject(fd,threshold=1000,units='pixels')"
    ]
@@ -115,7 +115,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.12"
+   "version": "3.11.2"
   }
  },
  "nbformat": 4,

--- a/docs/tutorial/tutorial.ipynb
+++ b/docs/tutorial/tutorial.ipynb
@@ -62,7 +62,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dem = tt3.load_dem('tibet')\n",
+    "dem = tt3.load_dem('bigtujunga')\n",
     "dem.info()"
    ]
   },
@@ -138,7 +138,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.12"
+   "version": "3.11.2"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Resolves #193

The Big Tujunga DEM has been added in TopoToolbox/DEMs#2, so it is now possible to access it using `load_dem`.