### PR TITLE
Correct the hillshade order test

### DIFF
--- a/tests/test_grid_object.py
+++ b/tests/test_grid_object.py
@@ -191,7 +191,7 @@ def test_hillshade_order():
     y = np.arange(0,256)
 
     demc = topo.GridObject()
-    demc.z = 64 * (opensimplex.noise2array(x,y) + 1)
+    demc.z = np.array(64 * (opensimplex.noise2array(x/13, y/13) + 1), dtype=np.float32)
     demc.cellsize = 13.0
     demc.transform = Affine.scale(demc.cellsize)
 
@@ -201,9 +201,10 @@ def test_hillshade_order():
     demf = topo.GridObject()
     demf.z = np.asfortranarray(demc.z)
     demf.cellsize = 13.0
-    demf.transform = Affine.scale(demf.cellsize)
+    # We also need to permute the geotransform to account for the swapped dimensions
+    demf.transform = Affine.rotation(180) * Affine.scale(demf.cellsize)
     
     for azimuth in np.arange(0.0,360.0,2.3):
         hc = demc.hillshade(azimuth=azimuth)
         hf = demf.hillshade(azimuth=azimuth)
-        assert np.array_equal(hc, hf)
+        assert np.allclose(hc, hf)


### PR DESCRIPTION
This test randomly generated double-precision DEMs, which were then passed to libtopotoolbox's hillshade as single-precision DEMs. The results were then incorrect, but compared equal to one another. This change forces the DEMs to be single-precision.

However, this change causes the test to fail because the geotransform created for the column-major array is identical to that of the row-major array. A rotation is applied to the column-major geotransform to correct this. `np.allclose` is now used for the comparison because the separate geotransforms lead to small numerical differences between the two hillshades. The length scale of the random DEMs is also increased because unrealistically steep gradients lead to increased numerical differences in the hillshades.