### PR TITLE
Fix the row/column major test for excesstopography

### DIFF
--- a/tests/test_grid_object.py
+++ b/tests/test_grid_object.py
@@ -144,7 +144,8 @@ def test_excesstopography_order():
     y = np.arange(0,256)
 
     dem_C = topo.GridObject()
-    dem_C.z = 64 * (opensimplex.noise2array(x,y) + 1)
+    dem_C.z = np.array(64 * (opensimplex.noise2array(x,y) + 1), dtype=np.float32)
+    dem_C.cellsize = 13.0
 
     assert dem_C.shape[0] == 256
     assert dem_C.shape[1] == 128
@@ -155,6 +156,7 @@ def test_excesstopography_order():
 
     dem_F = topo.GridObject()
     dem_F.z = np.asfortranarray(dem_C.z)
+    dem_F.cellsize = 13.0
 
     assert dem_F.shape[0] == 256
     assert dem_F.shape[1] == 128


### PR DESCRIPTION
As [noted](https://github.com/TopoToolbox/pytopotoolbox/pull/204#issuecomment-2760846869), the `excesstopography` memory order test should not have passed.

First we apply the datatype fix previously needed for fillsinks (#206) and hillshade (#205). Then we set the cellsize to make sure that gradients are computed correctly in excesstopography. This corrects the test, but the test now fails.

The following changes make the tests pass

1. Use the newly available (#196) np.asarray functionality for GridObjects to convert the threshold slope and DEM GridObjects.
2. Use np.full_like to construct `threshold_slopes` so that it matches the datatype, shape and order of the DEM. (#201)
3. Remove the datatype and memory layout checks.
4. Pass dims instead of shape (#200)