### PR TITLE
Add automatic downloads from OpenTopography 

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -12,8 +12,10 @@ API Documentation
    topotoolbox.read_tif
    topotoolbox.write_tif
    topotoolbox.load_dem
+   topotoolbox.load_open_topography
    topotoolbox.get_dem_names
    topotoolbox.get_cache_contents
+   topotoolbox.read_from_cache
    topotoolbox.clear_cache
    topotoolbox.gen_random
    topotoolbox.gen_random_bool

--- a/src/topotoolbox/utils.py
+++ b/src/topotoolbox/utils.py
@@ -5,6 +5,7 @@ import os
 import random
 from shutil import rmtree
 from urllib.request import urlopen, urlretrieve
+import requests
 
 import rasterio
 import numpy as np
@@ -12,10 +13,15 @@ import numpy as np
 from .grid_object import GridObject
 
 __all__ = ["load_dem", "get_dem_names", "read_tif", "gen_random", "write_tif",
-           "gen_random_bool", "get_cache_contents", "clear_cache"]
+           "gen_random_bool", "get_cache_contents", "clear_cache",
+           "read_from_cache", "load_open_topography"]
 
 DEM_SOURCE = "https://raw.githubusercontent.com/TopoToolbox/DEMs/master"
 DEM_NAMES = f"{DEM_SOURCE}/dem_names.txt"
+OPEN_TOPO_SOURCE = "https://portal.opentopography.org/API/globaldem"
+OPEN_TOPO_DATASETS = ('SRTMGL3', 'SRTMGL1', 'SRTMGL1_E', 'AW3D30', 'AW3D30_E'
+                      'SRTM15Plus', 'NASADEM', 'COP30', 'COP90', 'EU_DTM',
+                      'GEDI_L3', 'GEBCOIceTopo', 'GEBCOSubIceTopo')
 
 
 def write_tif(dem: GridObject, path: str) -> None:
@@ -56,6 +62,7 @@ def write_tif(dem: GridObject, path: str) -> None:
             transform=dem.transform
     ) as dataset:
         dataset.write(dem.z, 1)
+
 
 def read_tif(path: str) -> GridObject:
     """Generate a new GridObject from a .tif file.
@@ -313,3 +320,141 @@ def get_cache_contents() -> (list[str] | None):
 
     print("Cache directory does not exist.")
     return None
+
+
+def read_from_cache(filename: str) -> GridObject:
+    """Read a GeoTIFF file from the cache directory and return it as a
+    GridObject. The filename should be the name of the GeoTIFF file. Find
+    available files by using 'get_cache_contents()'.
+
+    Parameters
+    ----------
+    filename : str
+        Name of the file to be read from the cache directory. Requires the
+        whole filename including the extension, like "dem.tif".
+    Returns
+    -------
+    GridObject
+        The GridObject generated from the cached GeoTIFF file.
+    """
+    cache_path = os.path.join(get_save_location(), f"{filename}")
+    grid_object = read_tif(cache_path)
+    return grid_object
+
+
+def load_open_topography(south: float, north: float, west: float, east: float,
+                         dem_type: str = "SRTMGL3", overwrite: bool = False,
+                         save_path: str | None = None,
+                         api_key: str = "demoapikeyot2021") -> GridObject:
+    """Download a DEM from Open Topography. The DEM is downloaded as a
+    GeoTIFF file and saved in the cache directory. The DEM is then
+    read into a GridObject. To overwrite an existing Downloaded DEM, use
+    the overwrite parameter. To save the DEM to a different location,
+    use the save_path parameter. The API key is required for accessing
+    the Open Topography API. The default API key is the demo key.
+
+    Parameters
+    ----------
+    south : float
+        WGS 84 bounding box south coordinates
+    north : float
+        WGS 84 bounding box north coordinates
+    west : float
+        WGS 84 bounding box west coordinates
+    east : float
+        WGS 84 bounding box east coordinates
+    dem_type : str, optional
+        Choose one of the available global raster types, by default "SRTMGL3"
+
+        - SRTMGL3 (SRTM GL3 90m)
+        - SRTMGL1 (SRTM GL1 30m)
+        - SRTMGL1_E (SRTM GL1 Ellipsoidal 30m)
+        - AW3D30 (ALOS World 3D 30m)
+        - AW3D30_E (ALOS World 3D Ellipsoidal, 30m)
+        - SRTM15Plus (Global Bathymetry SRTM15+ V2.1 500m)
+        - NASADEM (NASADEM Global DEM)
+        - COP30 (Copernicus Global DSM 30m)
+        - COP90 (Copernicus Global DSM 90m)
+        - EU_DTM (DTM 30m)
+        - GEDI_L3 (DTM 1000m)
+        - GEBCOIceTopo (Global Bathymetry 500m)
+        - GEBCOSubIceTopo (Global Bathymetry 500m)
+
+    overwrite : bool, optional
+        If True cached DEM will be overwritten if it has the same bounds
+        and dem_type, by default False
+    save_path : str | None, optional
+        If provided, the downloadad GeoTIFF will be saved to this path. Like
+        this `"path/to/file.tif"` for example. By default None
+    api_key : str, optional
+        The API key for Open Topography. This is required to access the API.
+        If not provided, the demo key with limeted functionality will be used, 
+        by default "demoapikeyot2021"
+
+    Returns
+    -------
+    GridObject
+        A GridObject generated from the downloaded DEM.
+
+    Raises
+    ------
+    ValueError
+        If the provided DEM type is not valid.
+    ConnectionError
+        If the API request fails or returns an error.
+
+    Example
+    -------
+    dem = topotoolbox.load_open_topography(south=50, north=50.1, west=14.35,
+                    east=14.6, dem_type="SRTMGL3", api_key="demoapikeyot2022")
+    im = dem.plot(cmap="terrain")
+    plt.show()
+    """
+
+    if dem_type not in OPEN_TOPO_DATASETS:
+        raise ValueError(
+            f"Invalid DEM type. Available types are: {OPEN_TOPO_DATASETS}")
+
+    # Assemble the cache path. Create unique/Identifiable name for the GeoTIFF
+    dem = f"OpenTopo_{south}_{north}_{west}_{east}_{dem_type}"
+    cache_path = os.path.join(get_save_location(), f"{dem}.tif")
+
+    if not os.path.exists(cache_path) or overwrite:
+        url = (f"{OPEN_TOPO_SOURCE}"
+               f"?demtype={dem_type}"
+               f"&south={south}"
+               f"&north={north}"
+               f"&west={west}"
+               f"&east={east}"
+               f"&outputFormat=GTiff"
+               f"&API_Key={api_key}")
+        response = requests.get(url, stream=True, timeout=60)
+        if response.status_code == 200:
+            # Cache the DEM
+            with open(cache_path, 'wb') as f:
+                # 1 MB chunks (1024 * 1024 bytes)
+                for chunk in response.iter_content(chunk_size=1_048_576):
+                    f.write(chunk)
+        else:
+            error_dict = {
+                204: "Bad Data",
+                400: "Bad Request",
+                401: "Unauthorized (Check API key)",
+                500: "Internal Server Error"
+            }
+            code = response.status_code
+            err = f"Error: {code} - {error_dict[code]}"
+            raise ConnectionError(err) from None
+
+    if save_path:
+        # Copy cached file to specified save path
+        with open(cache_path, 'rb') as src, open(save_path, 'wb') as target:
+            while True:
+                # 1 MB chunks
+                chunk = src.read(1_048_576)
+                if not chunk:
+                    break
+                target.write(chunk)
+
+    grid_object = read_tif(cache_path)
+    return grid_object

--- a/src/topotoolbox/utils.py
+++ b/src/topotoolbox/utils.py
@@ -423,9 +423,9 @@ def load_open_topography(south: float, north: float, west: float, east: float,
     """
 
     # Check if an API key is provided
-    if api_key is str:
+    if isinstance(api_key, str):
         api = api_key
-    elif api_path is str:
+    elif isinstance(api_path, str):
         try:
             # since encoding is not predefined, use unspecified encoding
             # pylint: disable=unspecified-encoding
@@ -449,7 +449,7 @@ def load_open_topography(south: float, north: float, west: float, east: float,
         elif os.path.exists(os.path.expanduser('~/.opentopography.txt')):
             try:
                 # pylint: disable=unspecified-encoding
-                with open(os.path.expanduser("~/.opentopograpy.txt"), 'r') as file:
+                with open(os.path.expanduser("~/.opentopography.txt"), 'r') as file:
                     api = file.read().strip()
             except (FileNotFoundError, PermissionError):
                 pass
@@ -457,7 +457,7 @@ def load_open_topography(south: float, north: float, west: float, east: float,
             # No API key has been passed or found
             err = ("Neither api_key, api_env or api_path have been provided. "
                    "Default environment variable 'OPENTOPOGRAPHY_API_KEY' or "
-                   "file '~/.opentopograpy.txt' are not set. Use"
+                   "file '~/.opentopography.txt' are not set. Use"
                    " api_key='demoapikeyot2022' as the demo key.")
             raise ValueError(err) from None
 


### PR DESCRIPTION
This adds two new functions to `utils.py`:
- `load_open_topography()`
- `read_from_cache()`

This adds the ability to Load DEM's from OpenTopography by specifying the bounds, global raster dataset and an API-Key. These will be cached to avoid having to download them again if called with the same arguments. There is also the option to save them at a desired path. To make it easier to load already cached datasets, the function `read_from_cache()` can get them from the cache. This way the user can avoid having to input the whole path, if they haven't saved the TIF at a different place using the `save_path` argument.

closes #215