### PR TITLE
Transform bounds in GridObject.reproject 

### DIFF
--- a/src/topotoolbox/grid_object.py
+++ b/src/topotoolbox/grid_object.py
@@ -91,7 +91,10 @@ class GridObject():
         tuple
             The bounding box in the order (left, right, bottom, top)
         """
-        return (self.bounds.left, self.bounds.right, self.bounds.bottom, self.bounds.top)
+        if self.bounds:
+            return (self.bounds.left, self.bounds.right, self.bounds.bottom, self.bounds.top)
+        else:
+            return (-0.5, self.columns-0.5, self.rows-0.5, -0.5)
 
     def reproject(self,
                   crs: 'CRS',

--- a/src/topotoolbox/grid_object.py
+++ b/src/topotoolbox/grid_object.py
@@ -93,8 +93,8 @@ class GridObject():
         """
         if self.bounds:
             return (self.bounds.left, self.bounds.right, self.bounds.bottom, self.bounds.top)
-        else:
-            return (-0.5, self.columns-0.5, self.rows-0.5, -0.5)
+
+        return (-0.5, self.columns-0.5, self.rows-0.5, -0.5)
 
     def reproject(self,
                   crs: 'CRS',

--- a/src/topotoolbox/grid_object.py
+++ b/src/topotoolbox/grid_object.py
@@ -19,7 +19,8 @@ from scipy.ndimage import (
 from scipy.signal import wiener
 
 from rasterio import CRS, Affine
-from rasterio.warp import reproject
+from rasterio.coords import BoundingBox
+from rasterio.warp import reproject, transform_bounds
 from rasterio.enums import Resampling
 
 # pylint: disable=no-name-in-module
@@ -137,6 +138,9 @@ class GridObject():
         # Get cellsize from transform in case we did not specify one
         if dst.transform is not None:
             dst.cellsize = abs(dst.transform[0])
+
+        if self.bounds:
+            dst.bounds = BoundingBox(*transform_bounds(self.crs, dst.crs, *self.bounds))
 
         return dst
 


### PR DESCRIPTION
Resolves #217 

This uses rasterio functions to transform the bounding box after reprojection.

I also added a default bounding box for when `bounds`is `None`. This lets you plot GridObjects that are not georeferenced.