### PR TITLE
Implement `GridObject.astype`

### DIFF
--- a/src/topotoolbox/grid_object.py
+++ b/src/topotoolbox/grid_object.py
@@ -96,6 +96,32 @@ class GridObject():
 
         return (-0.5, self.columns-0.5, self.rows-0.5, -0.5)
 
+    def astype(self, dtype):
+        """Copy of the GridObject, cast to specified type
+
+        Parameters
+        ----------
+        dtype: str or np.dtype
+            The numpy data type to which the GridObject is cast
+
+        Returns
+        -------
+        GridObject
+            A copy of the original GridObject with the given data type
+        """
+        result = GridObject()
+        result.path = self.path
+        result.name = self.name
+        result.z = self.z.astype(dtype, copy=True)
+
+        result.cellsize = self.cellsize
+
+        result.bounds = self.bounds
+        result.transform = self.transform
+        result.crs = self.crs
+
+        return result
+
     def reproject(self,
                   crs: 'CRS',
                   resolution: 'float | None' = None,


### PR DESCRIPTION
This imitates `numpy.ndarray.astype` so that we can convert the underlying types of `GridObjects` the same way.

This is part of my attempt to get `imposemin` working using only duck-typing of `GridObjects` and `ndarrays` (#194).