### PR TITLE
Return copies from ezgetnal

### DIFF
--- a/src/topotoolbox/flow_object.py
+++ b/src/topotoolbox/flow_object.py
@@ -1,6 +1,5 @@
 """This module contains the FlowObject class.
 """
-import copy
 import numpy as np
 
 # pylint: disable=no-name-in-module
@@ -117,7 +116,7 @@ class FlowObject():
         self.transform = grid.transform
         self.crs = grid.crs
 
-    def ezgetnal(self, k):
+    def ezgetnal(self, k, dtype=None):
         """Retrieve a node attribute list
 
         Parameters
@@ -140,13 +139,11 @@ class FlowObject():
 
         """
         if np.isscalar(k):
-            return np.full(self.shape, k)
+            return np.full(self.shape, k, dtype=dtype)
         if not validate_alignment(self, k):
             raise ValueError("Input is not properly aligned to the FlowObject")
 
-        # Make sure we return a copy
-        # deepcopy is needed to copy the metadata if k is a GridObject
-        return copy.deepcopy(k)
+        return k.astype(dtype)
 
     def flow_accumulation(self, weights: np.ndarray | float = 1.0):
         """Computes the flow accumulation for a given flow network using

--- a/src/topotoolbox/flow_object.py
+++ b/src/topotoolbox/flow_object.py
@@ -1,5 +1,6 @@
 """This module contains the FlowObject class.
 """
+import copy
 import numpy as np
 
 # pylint: disable=no-name-in-module
@@ -124,7 +125,7 @@ class FlowObject():
         k : GridObject or np.ndarray or scalar        
             The object from which node values will be extracted. If
             `k` is a `GridObject` or an `ndarray` with the same shape
-            as this `FlowObject`, then it is returned. If it is a
+            as this `FlowObject`, then a copy is returned. If it is a
             scalar, an `ndarray` with the appropriate shape, filled
             with `k`, is returned.
 
@@ -143,7 +144,9 @@ class FlowObject():
         if not validate_alignment(self, k):
             raise ValueError("Input is not properly aligned to the FlowObject")
 
-        return k
+        # Make sure we return a copy
+        # deepcopy is needed to copy the metadata if k is a GridObject
+        return copy.deepcopy(k)
 
     def flow_accumulation(self, weights: np.ndarray | float = 1.0):
         """Computes the flow accumulation for a given flow network using

--- a/src/topotoolbox/grid_object.py
+++ b/src/topotoolbox/grid_object.py
@@ -1417,11 +1417,11 @@ class GridObject():
 
         self.z[index] = value
 
+    # pylint: disable=unused-argument
     def __array__(self, dtype=None, copy=None):
         if copy:
             return self.z.copy()
-        else:
-            return self.z
+        return self.z
 
     def __str__(self):
         return str(self.z)

--- a/src/topotoolbox/grid_object.py
+++ b/src/topotoolbox/grid_object.py
@@ -1418,14 +1418,10 @@ class GridObject():
         self.z[index] = value
 
     def __array__(self, dtype=None, copy=None):
-        try:
-            # If we are using Numpy v1.x, this will copy-if-needed
-            # when copy=False.
-            return np.array(self.z, dtype=dtype, copy=copy)
-        except ValueError:
-            # If np.array fails because copy=None and we are using an
-            # older version of Numpy, use asarray to copy-if-needed.
-            return np.asarray(self.z, dtype=dtype)
+        if copy:
+            return self.z.copy()
+        else:
+            return self.z
 
     def __str__(self):
         return str(self.z)

--- a/src/topotoolbox/stream_object.py
+++ b/src/topotoolbox/stream_object.py
@@ -230,7 +230,7 @@ class StreamObject():
 
         return dds
 
-    def ezgetnal(self, k):
+    def ezgetnal(self, k, dtype=None):
         """Retrieve a node attribute list from k
 
         Parameters
@@ -259,18 +259,19 @@ class StreamObject():
 
         """
         if np.isscalar(k):
-            nal = np.full(self.stream.shape, k)
+            nal = np.full(self.stream.shape, k, dtype=None)
         else:
             if validate_alignment(self, k):
                 # k is a GridObject or ndarray with the right shape
                 # and georeferencing
                 # Advanced indexing of k will always return a copy
                 nal = k[np.unravel_index(self.stream, self.shape, order='F')]
+
+                # We use copy=False in astype to avoid copying that copy if possible
+                nal = nal.astype(dtype, copy=False)
             elif hasattr(k,"shape") and self.stream.shape == k.shape:
                 # k is already a node attribute list
-                # Make sure that we return a copy
-                # The explicit call to copy is necessary to avoid type errors
-                nal = copy.deepcopy(k)
+                nal = np.array(k, dtype=dtype, copy=True)
             else:
                 raise ValueError(f"{k} is not a node attribute list of the appropriate shape.")
 

--- a/tests/test_flow_object.py
+++ b/tests/test_flow_object.py
@@ -26,6 +26,22 @@ def test_flowobject(wide_dem):
     # Ensure that FlowObject does not modify the original DEM
     assert np.all(dem.z == original_dem)
 
+def test_ezgetnal(wide_dem):
+    fd = topo.FlowObject(wide_dem)
+
+    z = fd.ezgetnal(wide_dem)
+    z2 = fd.ezgetnal(z.z)
+
+    assert isinstance(z, topo.GridObject)
+
+    # ezgetnal is idempotent
+    assert np.array_equal(z, wide_dem.z)
+    assert np.array_equal(z.z, z2)
+
+    # ezgetnal should always return a copy
+    assert z is not wide_dem
+    assert z2 is not z.z
+
 def test_flowpathextract(wide_dem):
     fd = topo.FlowObject(wide_dem)
     s = topo.StreamObject(fd)

--- a/tests/test_flow_object.py
+++ b/tests/test_flow_object.py
@@ -31,16 +31,24 @@ def test_ezgetnal(wide_dem):
 
     z = fd.ezgetnal(wide_dem)
     z2 = fd.ezgetnal(z.z)
+    z3 = fd.ezgetnal(wide_dem, dtype=np.float64)
 
     assert isinstance(z, topo.GridObject)
+    assert isinstance(z2, np.ndarray)
+    assert isinstance(z3, topo.GridObject)
 
     # ezgetnal is idempotent
-    assert np.array_equal(z, wide_dem.z)
+    assert np.array_equal(z, wide_dem)
     assert np.array_equal(z.z, z2)
+    assert np.array_equal(z3, wide_dem)
 
     # ezgetnal should always return a copy
     assert z is not wide_dem
     assert z2 is not z.z
+    assert z3 is not wide_dem
+
+    # ezgetnal with dtype should return array of that dtype
+    assert z3.z.dtype is np.dtype(np.float64)
 
 def test_flowpathextract(wide_dem):
     fd = topo.FlowObject(wide_dem)

--- a/tests/test_stream_object.py
+++ b/tests/test_stream_object.py
@@ -139,6 +139,19 @@ def test_stream_subgraphs(tall_dem, wide_dem):
     assert not issubgraph(wide_trunk, tall_stream)
     assert not issubgraph(tall_trunk, wide_stream)
 
+def test_ezgetnal(tall_dem):
+    fd = topo.FlowObject(tall_dem)
+    s = topo.StreamObject(fd)
+
+    z = s.ezgetnal(tall_dem)
+    z2 = s.ezgetnal(z)
+
+    # ezgetnal should be idempotent
+    assert np.array_equal(z, z2)
+
+    # ezgetnal should always return a copy
+    assert z is not z2
+
 def test_subgraph(tall_dem, wide_dem):
     ############
     # Tall DEM #

--- a/tests/test_stream_object.py
+++ b/tests/test_stream_object.py
@@ -145,12 +145,18 @@ def test_ezgetnal(tall_dem):
 
     z = s.ezgetnal(tall_dem)
     z2 = s.ezgetnal(z)
+    z3 = s.ezgetnal(z, dtype=np.float64)
 
     # ezgetnal should be idempotent
     assert np.array_equal(z, z2)
+    assert np.array_equal(z, z3)
 
     # ezgetnal should always return a copy
     assert z is not z2
+    assert z is not z3
+
+    # ezgetnal with the dtype argument should return array of that type
+    assert z3.dtype is np.dtype(np.float64)
 
 def test_subgraph(tall_dem, wide_dem):
     ############


### PR DESCRIPTION
This PR changes ezgetnal so that it always returns a copy of the input array. This problem emerged when working on imposemin (https://github.com/TopoToolbox/pytopotoolbox/pull/194) in trying to ensure that we pass views of the appropriate arrays to libtopotoolbox. This does duplicate arrays in some places where it isn't strictly necessary, and we might consider adding a `copy` argument akin to that on `numpy.array` that can suppress these copies.

Since we are copying the array anyway, it is not so hard to make sure that the returned arrays have a given element type especially with #219.

Tests are added to make sure that the copying works as anticipated and that the dtype is changed when requsted.

This also changes the implementation of the `__array__` method on `GridObject` so that it only copies when `copy=True`. Otherwise it trusts that Numpy will figure things out when you call `numpy.array(dem, copy=False)`. Making this compatible with the numpy pre-2.0 behavior while also relying on it to throw errors when copies were not possible was finicky.