### PR TITLE
Add memory ordering test for identifyflats

### DIFF
--- a/src/topotoolbox/grid_object.py
+++ b/src/topotoolbox/grid_object.py
@@ -269,10 +269,10 @@ class GridObject():
         if output is None:
             output = ['sills', 'flats']
 
-        dem = self.z.astype(np.float32, order='F')
+        dem = np.asarray(self,dtype=np.float32)
         output_grid = np.zeros_like(dem, dtype=np.int32)
 
-        _grid.identifyflats(output_grid, dem, self.shape)
+        _grid.identifyflats(output_grid, dem, self.dims)
 
         if raw:
             return (output_grid,)
@@ -280,13 +280,13 @@ class GridObject():
         result = []
         if 'flats' in output:
             flats = cp.copy(self)
-            flats.z = np.zeros_like(flats.z, order='F')
+            flats.z = np.zeros_like(flats.z)
             flats.z = np.where((output_grid & 1) == 1, 1, flats.z)
             result.append(flats)
 
         if 'sills' in output:
             sills = cp.copy(self)
-            sills.z = np.zeros_like(sills.z, order='F')
+            sills.z = np.zeros_like(sills.z)
             sills.z = np.where((output_grid & 2) == 2, 1, sills.z)
             result.append(sills)
 

--- a/src/topotoolbox/grid_object.py
+++ b/src/topotoolbox/grid_object.py
@@ -275,7 +275,7 @@ class GridObject():
         _grid.identifyflats(output_grid, dem, self.shape)
 
         if raw:
-            return tuple(output_grid)
+            return (output_grid,)
 
         result = []
         if 'flats' in output:
@@ -921,7 +921,7 @@ class GridObject():
             A 2D array of costs corresponding to each grid cell in the DEM.
         """
         dem = self.z
-        flats = self.identifyflats(raw=True)
+        flats = self.identifyflats(raw=True)[0]
         filled_dem = self.fillsinks().z
         dims = self.shape
         costs = np.zeros_like(dem, dtype=np.float32, order='F')
@@ -941,7 +941,7 @@ class GridObject():
             A 2D array representing the GWDT distances for each grid cell.
         """
         costs = self._gwdt_computecosts()
-        flats = self.identifyflats(raw=True)
+        flats = self.identifyflats(raw=True)[0]
         dims = self.shape
         dist = np.zeros_like(flats, dtype=np.float32, order='F')
         prev = np.zeros_like(flats, dtype=np.int64, order='F')
@@ -966,7 +966,7 @@ class GridObject():
         """
         filled_dem = self.fillsinks().z
         dist = self._gwdt()
-        flats = self.identifyflats(raw=True)
+        flats = self.identifyflats(raw=True)[0]
         dims = self.shape
         source = np.zeros_like(flats, dtype=np.int64, order='F')
         direction = np.zeros_like(flats, dtype=np.uint8, order='F')

--- a/tests/test_grid_object.py
+++ b/tests/test_grid_object.py
@@ -141,6 +141,42 @@ def test_identifyflats(square_dem, wide_dem, tall_dem):
                     if flats[i_neighbor, j_neighbor] < flats[i, j]:
                         assert flats[i, j] == 1.0
 
+def test_identifyflats_order():
+    opensimplex.seed(12)
+
+    x = np.arange(0, 128)
+    y = np.arange(0, 256)
+
+    cdem = topo.GridObject()
+    cdem.z = np.array(64 * (opensimplex.noise2array(x,y) + 1), dtype=np.float32)
+    cdem.cellsize = 13.0
+    cdem_filled = cdem.fillsinks()
+
+    fdem = topo.GridObject()
+    fdem.z = np.asfortranarray(cdem.z)
+    fdem.cellsize = 13.0
+    fdem_filled = fdem.fillsinks()
+
+    craw = cdem_filled.identifyflats(raw=True)[0]
+    fraw = fdem_filled.identifyflats(raw=True)[0]
+
+    assert np.array_equal(craw, fraw)
+
+    #assert craw.flags.c_contiguous
+    #assert fraw.flags.f_contiguous
+
+    cflats, csills = cdem_filled.identifyflats()
+    fflats, fsills = fdem_filled.identifyflats()
+
+    assert np.array_equal(cflats, fflats)
+    assert np.array_equal(csills, fsills)
+
+    assert cflats.z.flags.c_contiguous
+    assert csills.z.flags.c_contiguous
+    
+    assert fflats.z.flags.f_contiguous
+    assert fsills.z.flags.f_contiguous
+    
 def test_excesstopography(square_dem):
     # TODO: add more tests
     with pytest.raises(TypeError):

--- a/tests/test_grid_object.py
+++ b/tests/test_grid_object.py
@@ -162,8 +162,8 @@ def test_identifyflats_order():
 
     assert np.array_equal(craw, fraw)
 
-    #assert craw.flags.c_contiguous
-    #assert fraw.flags.f_contiguous
+    assert craw.flags.c_contiguous
+    assert fraw.flags.f_contiguous
 
     cflats, csills = cdem_filled.identifyflats()
     fflats, fsills = fdem_filled.identifyflats()


### PR DESCRIPTION
See #199

As with the other tests, we create a row-major and an identical column-major array, pass both to `identifyflats` and compare the outputs. We also check that the memory layout is preserved by `identifyflats`.

The row-major and column-major arrays already produced identical results in `identifyflats` because the input was converted to column-major before passing it through. This was caught by the second set of tests. By using `self.dims` instead of `self.shape` (#200) and removing the explicit conversion (#201), this test passes.

This also changes the return type of the `raw=True` option. Instead of returning `tuple(output_grid)`, it returns `(output_grid,)`. The former is a tuple of the rows of the output grid, and the latter is a one-element tuple of the 2D output grid, which is what we should use instead. Uses of identifyflats are updated for this new return type.