### PR TITLE
Type checking changes for Numpy v2.2

### DIFF
--- a/src/topotoolbox/grid_object.py
+++ b/src/topotoolbox/grid_object.py
@@ -4,6 +4,7 @@ import copy as cp
 from typing import Tuple, List
 
 import numpy as np
+import numpy.typing as npt
 
 import matplotlib.pyplot as plt
 from matplotlib import colors
@@ -42,7 +43,7 @@ class GridObject():
         self.name = ''
 
         # raster metadata
-        self.z = np.empty((), order='F', dtype=np.float32)
+        self.z: npt.NDArray = np.empty((), order='F', dtype=np.float32)
 
         self.cellsize = 0.0  # in meters if crs.is_projected == True
 
@@ -477,7 +478,7 @@ class GridObject():
         if unit == 'radian':
             output = np.arctan(output)
         elif unit == 'degree':
-            output = np.arctan(output) * (180.0 / np.pi)
+            output = np.rad2deg(np.arctan(output))
         elif unit == 'sine':
             output = np.sin(np.arctan(output))
         elif unit == 'percent':


### PR DESCRIPTION
Numpy v2.2 has introduced some new type checking annotations, and while we don't rely on any of these annotations, mypy unfortunately labels some errors.

Most importantly, there are new shape types, but not all of the numpy operations respect shape types, and these return a default shape type that is incompatible with a more specific type. If you then try to assign this to a variable that has already been assigned, you'll get a type error in mypy.

This affects us because we assign an empty ndarray to GridObject.z when we create a new GridObject from scratch. So calling

```python
output = GridObject()
output.z = np.zeros_like(dem.z)
```

will result in a type error, because the empty array created for output.z has a shape type that is incompatible with the type of np.zeros_like(dem.z).

This is fixed for now by annotating self.z with the most general NDArray type when we create an empty GridObject.

There is also a type problem when multiplying a float32 array by 180.0/np.pi in gradient8, which is fixed using np.rad2deg instead.

Note that these errors won't show up on CI because we currently run tests using numpy v2.1.3. We should probably run at least some of the tests on all of the supported numpy versions to catch regressions like this.