### PR TITLE
Add memory order test for gradient8

### DIFF
--- a/src/topotoolbox/grid_object.py
+++ b/src/topotoolbox/grid_object.py
@@ -469,10 +469,10 @@ class GridObject():
         else:
             use_mp = 0
 
-        dem = self.z.astype(np.float32, order='F')
+        dem = np.asarray(self.z, dtype=np.float32)
         output = np.zeros_like(dem)
 
-        _grid.gradient8(output, dem, self.cellsize, use_mp, self.shape)
+        _grid.gradient8(output, dem, self.cellsize, use_mp, self.dims)
         result = cp.copy(self)
 
         if unit == 'radian':

--- a/tests/test_grid_object.py
+++ b/tests/test_grid_object.py
@@ -282,3 +282,25 @@ def test_filter_order():
         ffiltered = fdem.filter(method=method)
 
         assert np.array_equal(cfiltered, ffiltered)
+
+def test_gradient8_order():
+    opensimplex.seed(12)
+
+    x = np.arange(0,128)
+    y = np.arange(0,256)
+
+    cdem = topo.GridObject()
+    cdem.z = np.array(64 * (opensimplex.noise2array(x,y) + 1), dtype=np.float32)
+    cdem.cellsize = 13.0
+
+    fdem = topo.GridObject()
+    fdem.z = np.asfortranarray(cdem.z)
+    fdem.cellsize = 13.0
+
+    cgradient = cdem.gradient8()
+    fgradient = fdem.gradient8()
+
+    assert np.array_equal(cgradient, fgradient)
+
+    assert cgradient.z.flags.c_contiguous
+    assert fgradient.z.flags.f_contiguous

--- a/tests/test_grid_object.py
+++ b/tests/test_grid_object.py
@@ -297,8 +297,16 @@ def test_gradient8_order():
     fdem.z = np.asfortranarray(cdem.z)
     fdem.cellsize = 13.0
 
-    cgradient = cdem.gradient8()
-    fgradient = fdem.gradient8()
+    cgradient = cdem.gradient8(multiprocessing=True)
+    fgradient = fdem.gradient8(multiprocessing=True)
+
+    assert np.array_equal(cgradient, fgradient)
+
+    assert cgradient.z.flags.c_contiguous
+    assert fgradient.z.flags.f_contiguous
+
+    cgradient = cdem.gradient8(multiprocessing=False)
+    fgradient = fdem.gradient8(multiprocessing=False)
 
     assert np.array_equal(cgradient, fgradient)
 


### PR DESCRIPTION
See #199

This has a similar structure to other memory order tests. This fails initially because `gradient8` converts its inputs to column major. It is fixed by applying #200 and #201, using the new array interface.