### PR TITLE
Add memory order test for curvature

### DIFF
--- a/tests/test_grid_object.py
+++ b/tests/test_grid_object.py
@@ -312,3 +312,23 @@ def test_gradient8_order():
 
     assert cgradient.z.flags.c_contiguous
     assert fgradient.z.flags.f_contiguous
+
+def test_curvature_order():
+    opensimplex.seed(12)
+
+    x = np.arange(0,128)
+    y = np.arange(0,256)
+
+    cdem = topo.GridObject()
+    cdem.z = np.array(64 * (opensimplex.noise2array(x,y) + 1), dtype=np.float32)
+    cdem.cellsize = 13.0
+
+    fdem = topo.GridObject()
+    fdem.z = np.asfortranarray(cdem.z)
+    fdem.cellsize = 13.0
+
+    for ctype in ['profc','planc','tangc','meanc','total']:
+        ccurv = cdem.curvature(ctype=ctype)
+        fcurv = fdem.curvature(ctype=ctype)
+
+        assert np.array_equal(ccurv, fcurv)


### PR DESCRIPTION
See #199

Like with filter, we don't test that curvature preserves the memory order of arrays because scipy.ndimage.convolve always returns row-major arrays.