### PR TITLE
Add memory order test for prominence

### DIFF
--- a/tests/test_grid_object.py
+++ b/tests/test_grid_object.py
@@ -263,3 +263,14 @@ def test_aspect_order(order_dems):
     faspect = fdem.aspect()
 
     assert np.array_equal(caspect, faspect)
+
+
+def test_prominence(order_dems):
+    cdem, fdem = order_dems
+
+    cp, (cx, cy) = cdem.prominence(10.0)
+    fp, (fx, fy) = fdem.prominence(10.0)
+
+    assert np.array_equal(cp, fp)
+    assert np.array_equal(cx, fx)
+    assert np.array_equal(cy, fy)

--- a/tests/test_grid_object.py
+++ b/tests/test_grid_object.py
@@ -268,8 +268,15 @@ def test_aspect_order(order_dems):
 def test_prominence(order_dems):
     cdem, fdem = order_dems
 
-    cp, (cx, cy) = cdem.prominence(10.0)
-    fp, (fx, fy) = fdem.prominence(10.0)
+    cp, (cx, cy) = cdem.prominence(10.0, use_hybrid=True)
+    fp, (fx, fy) = fdem.prominence(10.0, use_hybrid=True)
+
+    assert np.array_equal(cp, fp)
+    assert np.array_equal(cx, fx)
+    assert np.array_equal(cy, fy)
+
+    cp, (cx, cy) = cdem.prominence(10.0, use_hybrid=False)
+    fp, (fx, fy) = fdem.prominence(10.0, use_hybrid=False)
 
     assert np.array_equal(cp, fp)
     assert np.array_equal(cx, fx)


### PR DESCRIPTION
See #199 

This required some changes to `prominence` itself (#200, #201).