### PR TITLE
Fix memory ordering problems with FlowObject

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ include(FetchContent)
 FetchContent_Declare(
   topotoolbox
   GIT_REPOSITORY https://github.com/TopoToolbox/libtopotoolbox.git
-  GIT_TAG 6b631471b31d1cfef14193087ffe0a7a20bc1bcb
+  GIT_TAG 14809a9bff099e33048d52289d48c53cdf785605
 )
 FetchContent_MakeAvailable(topotoolbox)
 

--- a/src/lib/grid.cpp
+++ b/src/lib/grid.cpp
@@ -197,7 +197,9 @@ void wrap_flow_routing_d8_carve(
     std::array<ptrdiff_t, 2> dims_array = {std::get<0>(dims), std::get<1>(dims)};
     ptrdiff_t *dims_ptr = dims_array.data();
 
-    flow_routing_d8_carve(node_ptr, direction_ptr, dem_ptr, dist_ptr, flats_ptr, dims_ptr);
+    unsigned int order = (direction.flags() & py::array::c_style) ? 1 : 0;
+
+    flow_routing_d8_carve(node_ptr, direction_ptr, dem_ptr, dist_ptr, flats_ptr, dims_ptr, order);
 }
 
 // wrap_flow_routing_d8_edgelist:
@@ -223,7 +225,10 @@ ptrdiff_t wrap_flow_routing_d8_edgelist(
 
     std::array<ptrdiff_t, 2> dims_array = {std::get<0>(dims), std::get<1>(dims)};
     ptrdiff_t *dims_ptr = dims_array.data();
-    return flow_routing_d8_edgelist(source_ptr, target_ptr, node_ptr, direction_ptr, dims_ptr);
+
+    unsigned int order = (direction.flags() & py::array::c_style) ? 1 : 0;
+
+    return flow_routing_d8_edgelist(source_ptr, target_ptr, node_ptr, direction_ptr, dims_ptr, order);
 }
 
 // wrap_gradient8:

--- a/src/topotoolbox/flow_object.py
+++ b/src/topotoolbox/flow_object.py
@@ -43,10 +43,10 @@ class FlowObject():
         Large intermediate arrays are created during the initialization
         process, which could lead to issues when using very large DEMs.
         """
-        dims = grid.shape
-        dem = grid.z
+        dims = grid.dims
+        dem = np.asarray(grid, dtype=np.float32)
 
-        filled_dem = np.zeros_like(dem, dtype=np.float32, order='F')
+        filled_dem = np.zeros_like(dem, dtype=np.float32)
         restore_nans = False
         if bc is None:
             bc = np.ones_like(dem, dtype=np.uint8)
@@ -57,15 +57,14 @@ class FlowObject():
             bc[nans] = 1
             restore_nans = True
 
-        if bc.shape != dims:
+        if not validate_alignment(grid, bc):
             err = ("The shape of the provided boundary conditions does not "
                    f"match the shape of the DEM. {dims}")
             raise ValueError(err)from None
 
-        if isinstance(bc, GridObject):
-            bc = bc.z
+        bc = np.asarray(bc, dtype=np.uint8)
 
-        queue = np.zeros_like(dem, dtype=np.int64, order='F')
+        queue = np.zeros_like(dem, dtype=np.int64)
         if hybrid:
             _grid.fillsinks_hybrid(filled_dem, queue, dem, bc, dims)
         else:
@@ -75,24 +74,26 @@ class FlowObject():
             dem[nans] = np.nan
             filled_dem[nans] = np.nan
 
-        flats = np.zeros_like(dem, dtype=np.int32, order='F')
+        flats = np.zeros_like(dem, dtype=np.int32)
         _grid.identifyflats(flats, filled_dem, dims)
 
-        costs = np.zeros_like(dem, dtype=np.float32, order='F')
-        conncomps = np.zeros_like(dem, dtype=np.int64, order='F')
+        costs = np.zeros_like(dem, dtype=np.float32)
+        conncomps = np.zeros_like(dem, dtype=np.int64)
         _grid.gwdt_computecosts(costs, conncomps, flats, dem, filled_dem, dims)
 
-        dist = np.zeros_like(flats, dtype=np.float32, order='F')
+        dist = np.zeros_like(flats, dtype=np.float32)
         prev = conncomps  # prev: dtype=np.int64
         heap = queue      # heap: dtype=np.int64
-        back = np.zeros_like(flats, dtype=np.int64, order='F')
+        back = np.zeros_like(flats, dtype=np.int64)
         _grid.gwdt(dist, prev, costs, flats, heap, back, dims)
 
         node = heap  # node: dtype=np.int64
-        direction = np.zeros_like(dem, dtype=np.uint8, order='F')
+        direction = np.zeros_like(dem, dtype=np.uint8)
         _grid.flow_routing_d8_carve(
             node, direction, filled_dem, dist, flats, dims)
 
+        # ravel is used here to flatten the arrays. The memory order should not matter
+        # because we only need a block of contiguous memory interpreted as a 1D array.
         source = np.ravel(conncomps)  # source: dtype=int64
         target = np.ravel(back)       # target: dtype=int64
         edge_count = _grid.flow_routing_d8_edgelist(source, target, node, direction, dims)
@@ -101,7 +102,6 @@ class FlowObject():
         self.name = grid.name
 
         # raster metadata
-
         self.direction = direction  # dtype=np.unit8
 
         self.source = source[0:edge_count]  # dtype=np.int64

--- a/src/topotoolbox/flow_object.py
+++ b/src/topotoolbox/flow_object.py
@@ -19,7 +19,7 @@ class FlowObject():
 
     def __init__(self, grid: GridObject,
                  bc: np.ndarray | GridObject | None = None,
-                 hybrid : bool = True):
+                 hybrid: bool = True):
         """The constructor for the FlowObject. Takes a GridObject as input,
         computes flow direction information and saves them as an FlowObject.
 
@@ -96,7 +96,8 @@ class FlowObject():
         # because we only need a block of contiguous memory interpreted as a 1D array.
         source = np.ravel(conncomps)  # source: dtype=int64
         target = np.ravel(back)       # target: dtype=int64
-        edge_count = _grid.flow_routing_d8_edgelist(source, target, node, direction, dims)
+        edge_count = _grid.flow_routing_d8_edgelist(
+            source, target, node, direction, dims)
 
         self.path = grid.path
         self.name = grid.name
@@ -243,12 +244,12 @@ class FlowObject():
             An array containing column-major linear indices into the
             DEM identifying the flow path.
         """
-        ch = np.zeros(self.shape,dtype=np.uint32,order='F')
+        ch = np.zeros(self.shape, dtype=np.uint32, order='F')
         ch[np.unravel_index(idx, self.shape, order='F')] = 1
         edges = np.ones(self.source.size, dtype=np.uint32)
         _stream.traverse_down_u32_or_and(ch, edges, self.source, self.target)
 
-        return np.nonzero(np.ravel(ch,order='F'))[0]
+        return np.nonzero(np.ravel(ch, order='F'))[0]
 
     def distance(self):
         """Compute the distance between each node in the flow network

--- a/tests/test_flow_object.py
+++ b/tests/test_flow_object.py
@@ -6,19 +6,22 @@ import opensimplex
 
 import topotoolbox as topo
 
+
 @pytest.fixture
 def wide_dem():
     return topo.gen_random(rows=64, columns=128, seed=12)
+
 
 @pytest.fixture
 def order_dems():
     opensimplex.seed(12)
 
-    x = np.arange(0,128)
-    y = np.arange(0,256)
+    x = np.arange(0, 128)
+    y = np.arange(0, 256)
 
     cdem = topo.GridObject()
-    cdem.z = np.array(64 * (opensimplex.noise2array(x/13, y/13) + 1), dtype=np.float32)
+    cdem.z = np.array(
+        64 * (opensimplex.noise2array(x/13, y/13) + 1), dtype=np.float32)
     cdem.cellsize = 13.0
 
     fdem = topo.GridObject()
@@ -27,10 +30,11 @@ def order_dems():
 
     return [cdem, fdem]
 
+
 def test_flowobject(wide_dem):
     dem = wide_dem
     original_dem = dem.z.copy()
-    fd = topo.FlowObject(dem);
+    fd = topo.FlowObject(dem)
 
     assert topo.validate_alignment(dem, fd)
 
@@ -46,6 +50,7 @@ def test_flowobject(wide_dem):
     # Ensure that FlowObject does not modify the original DEM
     assert np.all(dem.z == original_dem)
 
+
 def test_flowobject_order(order_dems):
     cdem, fdem = order_dems
 
@@ -59,12 +64,15 @@ def test_flowobject_order(order_dems):
 
     # We can construct the isomorphism by recomputing the linear
     # indices of the row-major array in the column-major ordering.
-    idxmap = np.ravel_multi_index(np.unravel_index(np.arange(0, np.prod(cfd.shape)), cfd.shape, order='C'), ffd.shape, order='F')
+    idxmap = np.ravel_multi_index(np.unravel_index(
+        np.arange(0, np.prod(cfd.shape)), cfd.shape, order='C'), ffd.shape, order='F')
 
     # Now test whether the edge sets are identical
-    cedges = set(map(tuple, np.stack((idxmap[cfd.source], idxmap[cfd.target]), axis=1)))
+    cedges = set(
+        map(tuple, np.stack((idxmap[cfd.source], idxmap[cfd.target]), axis=1)))
     fedges = set(map(tuple, np.stack((ffd.source, ffd.target), axis=1)))
     assert cedges == fedges
+
 
 def test_ezgetnal(wide_dem):
     fd = topo.FlowObject(wide_dem)
@@ -90,6 +98,7 @@ def test_ezgetnal(wide_dem):
     # ezgetnal with dtype should return array of that dtype
     assert z3.z.dtype is np.dtype(np.float64)
 
+
 def test_flowpathextract(wide_dem):
     fd = topo.FlowObject(wide_dem)
     s = topo.StreamObject(fd)
@@ -111,13 +120,13 @@ def test_imposemin(wide_dem):
     original_dem = wide_dem.z.copy()
     fd = topo.FlowObject(wide_dem)
 
-    g0 = (wide_dem.z[np.unravel_index(fd.source,fd.shape,order='F')] -
-             wide_dem.z[np.unravel_index(fd.target,fd.shape,order='F')])/fd.distance()
+    g0 = (wide_dem.z[np.unravel_index(fd.source, fd.shape, order='F')] -
+          wide_dem.z[np.unravel_index(fd.target, fd.shape, order='F')])/fd.distance()
 
     # Make sure that the test array has slopes less than the imposed minimum
     assert not np.all(g0 >= 0.1 - 1e-6)
 
-    for minimum_slope in [0.0,0.001,0.01,0.1]:
+    for minimum_slope in [0.0, 0.001, 0.01, 0.1]:
         min_dem = topo.imposemin(fd, wide_dem, minimum_slope)
 
         # The carved dem should not be above the original
@@ -125,12 +134,13 @@ def test_imposemin(wide_dem):
 
         # The gradient along the flow network should be greater than or
         # equal to the defined slope within some numerical error
-        g = (min_dem.z[np.unravel_index(fd.source,fd.shape,order='F')] -
-             min_dem.z[np.unravel_index(fd.target,fd.shape,order='F')])/fd.distance()
+        g = (min_dem.z[np.unravel_index(fd.source, fd.shape, order='F')] -
+             min_dem.z[np.unravel_index(fd.target, fd.shape, order='F')])/fd.distance()
         assert np.all(g >= minimum_slope - 1e-6)
 
         # imposemin should not modify the original array
         assert np.array_equal(original_dem, wide_dem.z)
+
 
 def test_imposemin_f64(wide_dem):
     original_dem = np.array(wide_dem, dtype=np.float64)
@@ -143,10 +153,9 @@ def test_imposemin_f64(wide_dem):
 
     assert np.all(min_dem <= z)
 
-    g = (min_dem[np.unravel_index(fd.source,fd.shape,order='F')] -
-         min_dem[np.unravel_index(fd.target,fd.shape,order='F')])/fd.distance()
+    g = (min_dem[np.unravel_index(fd.source, fd.shape, order='F')] -
+         min_dem[np.unravel_index(fd.target, fd.shape, order='F')])/fd.distance()
     assert np.all(g >= 0.001 - 1e-6)
 
     # imposemin should not modify the original array
     assert np.array_equal(original_dem, z)
-    


### PR DESCRIPTION
Due to limitations in libtopotoolbox, flow routing is sensitive to the memory order of the input arrays. TopoToolbox/libtopotoolbox#186 modifies the API for flow_routing_d8_carve and flow_routing_d8_edgelist to take an order parameter (0 => column-major, 1 => row-major). This parameter corrects the search for flow directions so that the flow routing should be identical for identical arrays in either memory order. Our CMakeLists.txt is updated to include this change.

We do not pass the order flag through the Python API, but instead compute it by examining the flags() method on the direction pybind11::array. Note that all of the arrays should have the same memory ordering, but we do not currently enforce that in any way.

A test is added that compares the FlowObject for identical row-major and column-major arrays, following #199. The changes required for #200 and #201 are implemented in the FlowObject constructor.