### PR TITLE
Fix type stability bug in ezgetnal and plotdz

### DIFF
--- a/src/topotoolbox/stream_object.py
+++ b/src/topotoolbox/stream_object.py
@@ -268,7 +268,7 @@ class StreamObject():
                 nal = k[np.unravel_index(self.stream, self.shape, order='F')]
 
                 # We use copy=False in astype to avoid copying that copy if possible
-                nal = nal.astype(dtype, copy=False)
+                nal = nal.astype(dtype or nal.dtype, copy=False)
             elif hasattr(k,"shape") and self.stream.shape == k.shape:
                 # k is already a node attribute list
                 nal = np.array(k, dtype=dtype, copy=True)

--- a/src/topotoolbox/stream_object.py
+++ b/src/topotoolbox/stream_object.py
@@ -443,8 +443,8 @@ class StreamObject():
         if ax is None:
             ax = plt.gca()
         z = self.ezgetnal(z)
-        dist = np.zeros_like(z)
-        a = np.ones_like(z)
+        dist = np.zeros_like(z, dtype=np.float32)
+        a = np.ones_like(z, dtype=np.float32)
 
         # Compute upstream distance using streamquad_trapz_f32
         # Another traversal might be more efficient in the future

--- a/tests/test_stream_object.py
+++ b/tests/test_stream_object.py
@@ -155,6 +155,8 @@ def test_ezgetnal(tall_dem):
     assert z is not z2
     assert z is not z3
 
+    assert z.dtype == tall_dem.z.dtype
+    assert z2.dtype == tall_dem.z.dtype
     # ezgetnal with the dtype argument should return array of that type
     assert z3.dtype is np.dtype(np.float64)
 


### PR DESCRIPTION
When called with the default `dtype=None` parameter, `StreamObject.ezgetnal` changed the array's type to `np.float64`, which then caused problems in `plotdz` because arrays of `np.float64` were passed to libtopotoolbox. This change fixes the way the `dtype` parameter is used in `ezgetnal` and ensures that the arrays passed to libtopotoolbox are `np.float32`.