### PR TITLE
Support Python v3.12 and v3.13

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.10', '3.11']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest, macos-13]
         cibw_arch: ["native"]
-        cibw_build: ["cp310-* cp311-* cp312-*"]
+        cibw_build: ["cp310-* cp311-* cp312-* cp313-*"]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5


### PR DESCRIPTION
This adds 3.12 and 3.13 to the CI test runners and 3.13 to the wheels that we build and submit to PyPI.

https://scientific-python.org/specs/spec-0000/ is a good resource for figuring out which versions of things we should support at a minimum.