### PR TITLE
Implement `StreamObject.upstreamto`, `StreamObject.downstreamto` and `StreamObject.clean`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ include(FetchContent)
 FetchContent_Declare(
   topotoolbox
   GIT_REPOSITORY https://github.com/TopoToolbox/libtopotoolbox.git
-  GIT_TAG 14809a9bff099e33048d52289d48c53cdf785605
+  GIT_TAG e1f13871b15f75fb53f1743c13182071381f1295
 )
 FetchContent_MakeAvailable(topotoolbox)
 

--- a/src/lib/stream.cpp
+++ b/src/lib/stream.cpp
@@ -51,20 +51,20 @@ void wrap_streamquad_trapz_f64(py::array_t<double> integral,
                        weight_ptr, edge_count);
 }
 
-void wrap_traverse_up_u32_and(py::array_t<uint32_t> output,
-                              py::array_t<uint32_t> input,
-                              py::array_t<ptrdiff_t> source,
-                              py::array_t<ptrdiff_t> target) {
+void wrap_traverse_up_u32_or_and(py::array_t<uint32_t> output,
+                                 py::array_t<uint32_t> input,
+                                 py::array_t<ptrdiff_t> source,
+                                 py::array_t<ptrdiff_t> target) {
 
   uint32_t *output_ptr = output.mutable_data();
   uint32_t *input_ptr = input.mutable_data();
   ptrdiff_t *source_ptr = source.mutable_data();
   ptrdiff_t *target_ptr = target.mutable_data();
 
-  ptrdiff_t edge_count = source.size(); 
+  ptrdiff_t edge_count = source.size();
 
-  traverse_up_u32_and(output_ptr, input_ptr, source_ptr,
-                      target_ptr, edge_count);  
+  traverse_up_u32_or_and(output_ptr, input_ptr, source_ptr,
+                         target_ptr, edge_count);
 }
 
 void wrap_traverse_down_u32_or_and(py::array_t<uint32_t> output,
@@ -77,10 +77,10 @@ void wrap_traverse_down_u32_or_and(py::array_t<uint32_t> output,
   ptrdiff_t *source_ptr = source.mutable_data();
   ptrdiff_t *target_ptr = target.mutable_data();
 
-  ptrdiff_t edge_count = source.size(); 
+  ptrdiff_t edge_count = source.size();
 
   traverse_down_u32_or_and(output_ptr, input_ptr, source_ptr,
-                           target_ptr, edge_count);  
+                           target_ptr, edge_count);
 }
 
 void wrap_traverse_down_f32_max_add(py::array_t<float> output,
@@ -159,7 +159,7 @@ void wrap_propagatevaluesupstream_u8(py::array_t<uint8_t> data,
 PYBIND11_MODULE(_stream, m) {
   m.def("streamquad_trapz_f32", &wrap_streamquad_trapz_f32);
   m.def("streamquad_trapz_f64", &wrap_streamquad_trapz_f64);
-  m.def("traverse_up_u32_and", &wrap_traverse_up_u32_and);
+  m.def("traverse_up_u32_or_and", &wrap_traverse_up_u32_or_and);
   m.def("traverse_down_u32_or_and", &wrap_traverse_down_u32_or_and);
   m.def("traverse_down_f32_max_add", &wrap_traverse_down_f32_max_add);
   m.def("traverse_down_f32_min_add", &wrap_traverse_down_f32_min_add);

--- a/src/topotoolbox/stream_object.py
+++ b/src/topotoolbox/stream_object.py
@@ -416,7 +416,7 @@ class StreamObject():
         >>> fd = topotoolbox.FlowObject(dem)
         >>> s = topotoolbox.StreamObject(fd,threshold=1000,units='pixels')
         >>> plt.subplots()
-        >>> dem.plot(cmap="terrain")    
+        >>> dem.plot(cmap="terrain")
         >>> s.plot(color='r')
         """
 
@@ -764,6 +764,74 @@ class StreamObject():
         # TODO(wkearn): clean(result)
         # TODO(wkearn): return indices into the original node attribute list
         return result
+
+    def upstreamto(self, nodes) -> 'StreamObject':
+        """Extract the portion of the stream network upstream of the given nodes
+
+        Parameters
+        ----------
+        nodes: GridObject or np.ndarray
+            A logical node attribute list or grid that is True for the desired nodes.
+
+        Returns
+        -------
+        StreamObject
+            A stream network containing those nodes of the original
+            one that are upstream of the given nodes.
+
+        Example
+        -------
+        >>> import numpy as np
+        >>> import matplotlib.pyplot as plt
+        >>> dem = topotoolbox.load_dem('perfectworld')
+        >>> fd = topotoolbox.FlowObject(dem)
+        >>> s = topotoolbox.StreamObject(fd,threshold=1000,units='pixels')
+        >>> confluences = s.streampoi('confluences')
+        >>> s2 = s.upstreamto(confluences)
+        >>> fig,ax = plt.subplots()
+        >>> dem.plot(ax=ax,cmap="terrain")
+        >>> s2.plot(ax=ax,color='k')
+        """
+        nal = self.ezgetnal(nodes, dtype=np.uint32)
+
+        edges = np.ones(self.source.size, dtype=np.uint32)
+        _stream.traverse_up_u32_or_and(nal, edges, self.source, self.target)
+
+        return self.subgraph(nal)
+
+    def downstreamto(self, nodes) -> 'StreamObject':
+        """Extract the portion of the stream network downstream of the given nodes
+
+        Parameters
+        ----------
+        nodes: GridObject or np.ndarray
+            A logical node attribute list or grid that is True for the desired nodes.
+
+        Returns
+        -------
+        StreamObject
+            A stream network containing those nodes of the original
+            one that are downstream of the given nodes.
+
+        Example
+        -------
+        >>> import numpy as np
+        >>> import matplotlib.pyplot as plt
+        >>> dem = topotoolbox.load_dem('perfectworld')
+        >>> fd = topotoolbox.FlowObject(dem)
+        >>> s = topotoolbox.StreamObject(fd,threshold=1000,units='pixels')
+        >>> confluences = s.streampoi('confluences')
+        >>> s2 = s.downstream(confluences)
+        >>> fig,ax = plt.subplots()
+        >>> dem.plot(ax=ax,cmap="terrain")
+        >>> s2.plot(ax=ax,color='k')
+        """
+        nal = self.ezgetnal(nodes, dtype=np.uint32)
+
+        edges = np.ones(self.source.size, dtype=np.uint32)
+        _stream.traverse_down_u32_or_and(nal, edges, self.source, self.target)
+
+        return self.subgraph(nal)
 
     # 'Magic' functions:
     # ------------------------------------------------------------------------

--- a/tests/test_stream_object.py
+++ b/tests/test_stream_object.py
@@ -266,7 +266,7 @@ def test_stream_channelheads(tall_dem, wide_dem):
     s = topo.StreamObject(fd)
 
     assert topo.validate_alignment(fd, s)
-    
+
     channel_heads = s.streampoi("channelheads")
 
     s2 = topo.StreamObject(fd, channelheads=s.stream[channel_heads])
@@ -275,6 +275,19 @@ def test_stream_channelheads(tall_dem, wide_dem):
 
     assert np.array_equal(s2.stream[s2.source], s.stream[s.source])
     assert np.array_equal(s2.stream[s2.target], s.stream[s.target])
+
+def test_stream_downstreamto(tall_dem):
+    fd = topo.FlowObject(tall_dem)
+    s = topo.StreamObject(fd)
+
+    ch = s.streampoi("channelheads")
+
+    sc = topo.StreamObject(fd,channelheads=s.stream[ch])
+    sd = s.downstreamto(ch)
+
+    # These two stream networks should be equivalent
+    assert len(set(sd.stream).symmetric_difference(set(sc.stream))) == 0
+
 
 def test_stream_imposemin(tall_dem, wide_dem):
     fd = topo.FlowObject(tall_dem)

--- a/tests/test_stream_object.py
+++ b/tests/test_stream_object.py
@@ -288,6 +288,21 @@ def test_stream_downstreamto(tall_dem):
     # These two stream networks should be equivalent
     assert len(set(sd.stream).symmetric_difference(set(sc.stream))) == 0
 
+def test_stream_upstreamto(tall_dem):
+    fd = topo.FlowObject(tall_dem)
+
+    # We clean here in case any 1 pixel streams exist in s.
+    # They won't be identified as outlets, so the reconstructed stream
+    # network would not be identical to the original.
+    s = topo.StreamObject(fd).clean()
+
+    outlets = s.streampoi("outlets")
+
+    su = s.upstreamto(outlets)
+
+    # These two stream networks should be equivalent
+    assert len(set(s.stream).symmetric_difference(set(su.stream))) == 0
+
 
 def test_stream_imposemin(tall_dem, wide_dem):
     fd = topo.FlowObject(tall_dem)


### PR DESCRIPTION
These are a few methods that implement specific versions of `modify` (#140). I am starting to think that exposing these more basic methods is a nicer interface than `modify` with a ton of keyword arguments, especially because those keyword arguments require different types of input. For example, `rmupstreamtoch` takes another `StreamObject` while `streamorder` actually tries to parse an expression.  These three are all based on node attribute lists/GridObjects and a traversal, so they are pretty straightforward.

Tests are added for `upstreamto` and `downstreamto`. The `upstreamto` test makes use of `clean`, but does not actively test it unless the `tall_dem` fixture happens to have some disconnected pixels in its stream network.