### PR TITLE
Add memory order test for flow_accumulation

### DIFF
--- a/src/topotoolbox/flow_object.py
+++ b/src/topotoolbox/flow_object.py
@@ -116,6 +116,7 @@ class FlowObject():
         self.shape = grid.shape
         self.cellsize = grid.cellsize
         self.strides = tuple(s // grid.z.itemsize for s in grid.z.strides)
+        self.order = 'F' if grid.z.flags.f_contiguous else 'C'
 
         # georeference
         self.bounds = grid.bounds
@@ -188,17 +189,19 @@ class FlowObject():
         >>> acc = fd.flow_accumulation()
         >>> acc.plot(cmap='Blues',norm="log")
         """
-        acc = np.zeros(self.shape, dtype=np.float32, order='F')
+        acc = np.zeros(self.shape, dtype=np.float32, order=self.order)
 
+        # This is overly complicated
         if weights == 1.0:
-            weights = np.ones(self.shape, dtype=np.float32, order='F')
+            weights = np.ones(self.shape, dtype=np.float32, order=self.order)
         elif isinstance(weights, np.ndarray):
             if weights.shape != acc.shape:
                 err = ("The shape of the provided weights ndarray does not "
                        f"match the shape of the FlowObject. {self.shape}")
                 raise ValueError(err)from None
         else:
-            weights = np.full(self.shape, weights, dtype=np.float32, order='F')
+            weights = np.full(self.shape, weights,
+                              dtype=np.float32, order=self.order)
 
         fraction = np.ones_like(self.source, dtype=np.float32)
 

--- a/src/topotoolbox/flow_object.py
+++ b/src/topotoolbox/flow_object.py
@@ -118,7 +118,7 @@ class FlowObject():
         self.shape = grid.shape
         self.cellsize = grid.cellsize
         self.strides = tuple(s // grid.z.itemsize for s in grid.z.strides)
-        self.order: Literal['F', 'C'] = ('F' if grid.z.flags.c_contiguous
+        self.order: Literal['F', 'C'] = ('F' if grid.z.flags.f_contiguous
                                          else 'C')
 
         # georeference

--- a/src/topotoolbox/flow_object.py
+++ b/src/topotoolbox/flow_object.py
@@ -1,5 +1,7 @@
 """This module contains the FlowObject class.
 """
+from typing import Literal
+
 import numpy as np
 
 # pylint: disable=no-name-in-module
@@ -116,7 +118,8 @@ class FlowObject():
         self.shape = grid.shape
         self.cellsize = grid.cellsize
         self.strides = tuple(s // grid.z.itemsize for s in grid.z.strides)
-        self.order = 'F' if grid.z.flags.f_contiguous else 'C'
+        self.order: Literal['F', 'C'] = ('F' if grid.z.flags.c_contiguous
+                                         else 'C')
 
         # georeference
         self.bounds = grid.bounds

--- a/tests/test_flow_object.py
+++ b/tests/test_flow_object.py
@@ -74,6 +74,18 @@ def test_flowobject_order(order_dems):
     assert cedges == fedges
 
 
+def test_flow_accumulation_order(order_dems):
+    cdem, fdem = order_dems
+
+    cfd = topo.FlowObject(cdem)
+    ffd = topo.FlowObject(fdem)
+
+    ca = cfd.flow_accumulation()
+    fa = ffd.flow_accumulation()
+
+    assert np.array_equal(ca, fa)
+
+
 def test_ezgetnal(wide_dem):
     fd = topo.FlowObject(wide_dem)
 


### PR DESCRIPTION
See #199

Create DEMs in row- and column-major order, route flow and compute
flow accumulation. These two outputs should be identical.

This test fails with current pytopotoolbox. The flow accumulation rasters are generated in
column-major order, but the source and target indices are either row-
or column-major depending on the source DEM, so the row-major accesses
the incorrect values. This is incorrect, but does not access memory
out of bounds.

A minimal solution to the failed memory order test adds an
`order` attribute to the `FlowObject` and creates the accumulation and
weights rasters with the correct order. The test now passes. I am
unsure if this is a good long-term solution.

Both `FlowObject` and `StreamObject` need to know the
memory order of their underlying grids because they need to be able to
unravel their source and target to index into the grid. For
`FlowObject`

```python
grid.z[np.unravel_index(fd.source, fd.shape, order=fd.order)]
```

while for `StreamObject`, you need the extra indirection of the
`stream` array

```python
grid.z[np.unravel_index(s.stream[s.source], s.shape, order=s.order)]
```

Passing around this order information as a string is somewhat unsafe, but it does work for now. The existence of the test will prevent this from breaking if we do move to a more robust way to handle the memory order information.