### PR TITLE
Test the memory order independence of drainagebasins 

### DIFF
--- a/src/topotoolbox/flow_object.py
+++ b/src/topotoolbox/flow_object.py
@@ -126,6 +126,15 @@ class FlowObject():
         self.transform = grid.transform
         self.crs = grid.crs
 
+    @property
+    def dims(self):
+        """The dimensions of the grid in the correct order for libtopotoolbox
+        """
+        if self.order == 'C':
+            return (self.shape[0], self.shape[1])
+
+        return (self.shape[1], self.shape[0])
+
     def ezgetnal(self, k, dtype=None) -> GridObject | np.ndarray:
         """Retrieve a node attribute list
 
@@ -247,14 +256,15 @@ class FlowObject():
         >>> basins.shufflelabel().plot(cmap="Pastel1",interpolation="nearest")
 
         """
-        basins = np.zeros(self.shape, dtype=np.int64, order='F')
+        basins = np.zeros(self.shape, dtype=np.int64, order=self.order)
 
         if outlets is None:
-            _flow.drainagebasins(basins, self.source, self.target, self.shape)
+            _flow.drainagebasins(basins, self.source, self.target, self.dims)
         else:
-            indices = np.unravel_index(outlets, self.shape, order='F')
+            indices = np.unravel_index(outlets, self.shape, order=self.order)
             basins[indices] = np.arange(1, len(outlets) + 1)
-            _stream.propagatevaluesupstream_i64(basins, self.source, self.target)
+            _stream.propagatevaluesupstream_i64(basins, self.source,
+                                                self.target)
 
         result = GridObject()
         result.path = self.path

--- a/tests/test_flow_object.py
+++ b/tests/test_flow_object.py
@@ -126,16 +126,17 @@ def test_drainagebasins_order(order_dems):
     # B array with the alternate `invs`, we will get the main labels
     # that should be assigned to each pixel in the alternate array if
     # the two arrays are identical up to the bijection.
-    frec = fus[finvs[np.unravel_index(cidxs, cdb.shape)]][cinvs]
+    frec = fus[np.take(finvs, cidxs)][cinvs]
 
     # Now we test that the reconstructed array is identical to the
-    # main array.
-    assert np.array_equal(frec, fdb)
+    # main array. We use flatten because older versions of numpy
+    # return different `invs` of different dimensions.
+    assert np.array_equal(frec.flatten(), fdb.z.flatten())
 
     # Having done this once, we might as well do it with the main and
     # alternate arrays swapped.
-    crec = cus[cinvs[np.unravel_index(fidxs, fdb.shape)]][finvs]
-    assert np.array_equal(crec, cdb)
+    crec = cus[np.take(cinvs, fidxs)][finvs]
+    assert np.array_equal(crec.flatten(), cdb.z.flatten())
 
 
 def test_ezgetnal(wide_dem):

--- a/tests/test_flow_object.py
+++ b/tests/test_flow_object.py
@@ -86,6 +86,58 @@ def test_flow_accumulation_order(order_dems):
     assert np.array_equal(ca, fa)
 
 
+def test_drainagebasins_order(order_dems):
+    cdem, fdem = order_dems
+
+    cfd = topo.FlowObject(cdem)
+    ffd = topo.FlowObject(fdem)
+
+    cdb = cfd.drainagebasins()
+    fdb = ffd.drainagebasins()
+
+    # This testing logic is rather complicated, so please excuse the
+    # length explanation.
+
+    # The two sets of labels are identical up to a bijection between
+    # the label sets. We construct that bijection here. We need the
+    # set of unique labels, `us`, the indices of a representative pixel
+    # in the drainage basins array that has each label, `idxs`, and, for
+    # each pixel, the index of its label in the label set, `invs`. If we
+    # have B basins in an N x M DEM, `us` is a length B array of basin
+    # labels, `idxs` is an length B array of pixel indices and `invs` is
+    # an N x M array of the indices [0,B-1) into the `us`
+    # array. Fortunately np.unique can provide all of these.
+    cus, cidxs, cinvs = np.unique(cdb, return_index=True, return_inverse=True)
+    fus, fidxs, finvs = np.unique(fdb, return_index=True, return_inverse=True)
+
+    # Now we construct the bijection and apply it to reconstruct the
+    # column-major and row-major drainage basins. Below the "main array"
+    # refers to the array whose pattern we are trying to reconstruct
+    # and the "alternate array" is the one we reconstruct from.
+
+    # First, we use the `idxs` of the alternate array to extract the
+    # `invs` of the main array at each of the representative
+    # pixels. Then we index into the `us` of the main array to find
+    # the labels assigned to each of the representative pixels /in the
+    # order in which they show up in the alternate `idxs` array/,
+    # which is also the order of the labels in the alternate `us`
+    # array. This array represents the bijection between the main
+    # labels and the alternate labels. When we index into this length
+    # B array with the alternate `invs`, we will get the main labels
+    # that should be assigned to each pixel in the alternate array if
+    # the two arrays are identical up to the bijection.
+    frec = fus[finvs[np.unravel_index(cidxs, cdb.shape)]][cinvs]
+
+    # Now we test that the reconstructed array is identical to the
+    # main array.
+    assert np.array_equal(frec, fdb)
+
+    # Having done this once, we might as well do it with the main and
+    # alternate arrays swapped.
+    crec = cus[cinvs[np.unravel_index(fidxs, fdb.shape)]][finvs]
+    assert np.array_equal(crec, cdb)
+
+
 def test_ezgetnal(wide_dem):
     fd = topo.FlowObject(wide_dem)
 


### PR DESCRIPTION
See #199

This test requires some fiddly indexing logic to deal with
permutations of the drainage basin labels, which I hope is
well-explained by the comments.

This test fails at first, because the basins array is created with a column-major order. 
Fixing it  is mostly a matter of using `FlowObject.order` to construct the
right kind of output arrays. It also requires a new `FlowObject.dims`
attribute to pass the dimensions in the correct order.