### PR TITLE
Tag the Next Steps section with nbsphinx-toctree

### DIFF
--- a/docs/tutorial/tutorial.ipynb
+++ b/docs/tutorial/tutorial.ipynb
@@ -136,7 +136,15 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": [
+     "nbsphinx-toctree"
+    ]
+   },
    "source": [
     "## Next steps\n",
     "\n",


### PR DESCRIPTION
This makes the other notebooks show up in the table of contents in the left sidebar.

@Teschl: did this tag get stripped by the`nbstripout` pre-commit hook? It looks like it got removed in #208, but I didn't notice it then. I just ran the hook when I made the commit, and it did not remove it, but perhaps you have some lingering local configuration that does strip it?