### PR TITLE
Fix some links regarding the new template notebook

### DIFF
--- a/docs/dev.rst
+++ b/docs/dev.rst
@@ -145,4 +145,5 @@ The pre-commit-config contains the following hooks:
    :maxdepth: 1
    :hidden:
 
-   Example Notebook for TopoToolbox <dev/template>
+   dev/template
+   dev/wrapping

--- a/docs/dev/template.ipynb
+++ b/docs/dev/template.ipynb
@@ -13,7 +13,7 @@
     "\n",
     "Give your example a descriptive title (e.g. \"Example notebook for TopoToolbox\") as a top-level heading at the beginning of your notebook. The filename (e.g. \"template.ipynb\") must be unique among our example notebooks and should also be descriptive.\n",
     "\n",
-    "This example notebook lives in the `docs/dev` folder, but you should put yours in [`docs/examples`](https://github.com/TopoToolbox/pytopotoolbox/tree/main/docs/examples). Add the filename for your example without the `.ipynb` extension to [`docs/examples.rst`](https://github.com/TopoToolbox/pytopotoolbox/blob/main/docs/examples.rst)` to have your notebook show up in our [Examples gallery](https://topotoolbox.github.io/pytopotoolbox/examples.html).\n",
+    "This example notebook lives in the docs/dev folder, but you should put yours in [docs/examples](https://github.com/TopoToolbox/pytopotoolbox/tree/main/docs/examples). Add the filename for your example without the `.ipynb` extension to [docs/examples.rst](https://github.com/TopoToolbox/pytopotoolbox/blob/main/docs/examples.rst)` to have your notebook show up in our [Examples gallery](../examples.rst).\n",
     "\n",
     "## Authors\n",
     "\n",
@@ -43,7 +43,7 @@
     "\n",
     "You will need to import dependencies before running any code that requires those dependencies. Feel free to do so all at once at the beginning, as shown here, or only when you need particular functionality.\n",
     "\n",
-    "In addition to `topotoolbox`, users can be expected to have [`matplotlib`](https://matplotlib.org/), [`numpy`](https://numpy.org/), [`rasterio`](https://rasterio.readthedocs.io/en/stable/) and [`scipy`](https://scipy.org/) because TopoToolbox directly depends on those packages."
+    "In addition to topotoolbox, users can be expected to have [matplotlib](https://matplotlib.org/), [numpy](https://numpy.org/), [rasterio](https://rasterio.readthedocs.io/en/stable/) and [scipy](https://scipy.org/) because TopoToolbox directly depends on those packages."
    ]
   },
   {
@@ -68,7 +68,7 @@
    "source": [
     "If you have other dependencies, you can add instructions for installing those dependencies here. Avoid using magic commands like `%pip` to install packages from within a notebook because users may prefer to install packages in a different manner.\n",
     "\n",
-    "Dependencies other than the ones listed above that are required to run the notebook should also be added to the [`docs/requirements.txt`](https://github.com/TopoToolbox/pytopotoolbox/blob/main/docs/requirements.txt) file in the pytopotoolbox repository. These are not installed by default when a user installs pytopotoolbox. Instead, they are installed when the notebooks are compiled into HTML on our continuous integration server. If the packages are not listed there, they will not be available during compilation and the build process will fail. Be judicious in what dependencies you add here. We will review them and may ask you to make changes to your code if you add too many dependencies or ones that are not essential to your example."
+    "Dependencies other than the ones listed above that are required to run the notebook should also be added to the [docs/requirements.txt](https://github.com/TopoToolbox/pytopotoolbox/blob/main/docs/requirements.txt) file in the pytopotoolbox repository. These are not installed by default when a user installs pytopotoolbox. Instead, they are installed when the notebooks are compiled into HTML on our continuous integration server. If the packages are not listed there, they will not be available during compilation and the build process will fail. Be judicious in what dependencies you add here. We will review them and may ask you to make changes to your code if you add too many dependencies or ones that are not essential to your example."
    ]
   },
   {
@@ -138,7 +138,7 @@
     "\n",
     "Once you have developed your notebook, you can submit it to TopoToolbox by making a pull request on GitHub. More information about this process is available on the [TopoToolbox website](https://topotoolbox.github.io/contributing.html#contributing-via-pull-requests). Please get in touch if you are having trouble!\n",
     "\n",
-    "The one additional thing to be aware of when committing Jupyter Notebooks to our repository is that you will need to strip the code outputs and metadata out of the notebook before you commit the code in git. We use the [`nbstripout`](https://github.com/kynan/nbstripout) utility to help us do this. Install `nbstripout` with\n",
+    "The one additional thing to be aware of when committing Jupyter Notebooks to our repository is that you will need to strip the code outputs and metadata out of the notebook before you commit the code in git. We use the [nbstripout](https://github.com/kynan/nbstripout) utility to help us do this. Install nbstripout with\n",
     "\n",
     "```bash\n",
     "pip install nbstripout\n",

--- a/docs/dev/wrapping.ipynb
+++ b/docs/dev/wrapping.ipynb
@@ -206,25 +206,7 @@
    ]
   }
  ],
- "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.10.12"
-  }
- },
+ "metadata": {},
  "nbformat": 4,
  "nbformat_minor": 2
 }

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -28,7 +28,7 @@ For further documentation regarding the functionality of this package, check out
 Contributing
 ------------
 
-If you would like to contribute to pytopotoolbox, refer to the :doc:`CONTRIBUTING` page. To get a better understanding of how we wrap functions for use in python, the :doc:`wrapping` page will help.
+If you would like to contribute to pytopotoolbox, refer to the :doc:`CONTRIBUTING` page. A great way to get started is to :doc:`create a notebook <dev/template>` for our :doc:`examples` gallery. To get a better understanding of how we wrap libtopotoolbox functions for use in Python, the :doc:`dev/wrapping` page will help.
 
 .. toctree::
    :maxdepth: 1
@@ -39,7 +39,6 @@ If you would like to contribute to pytopotoolbox, refer to the :doc:`CONTRIBUTIN
    API <api>
    Contribution Guidelines <CONTRIBUTING>
    Developer Documentation <dev>
-   Wrapping LibTopoToolbox <wrapping>
 
 Indices and Tables
 ------------------


### PR DESCRIPTION
This also moves the wrapping notebook into the new `dev` folder so it shows up under Developer Documentation in the sidebar.