### PR TITLE
Add shapely and geopandas dependencies to pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,6 +21,8 @@ repos:
           - matplotlib
           - scipy
           - rasterio
+          - shapely
+          - geopandas
         exclude: |
           (?x)^(
             tests/|


### PR DESCRIPTION
These dependencies were added to the package in #260. They must also be added to pre-commit to make sure that pylint can find them when it is run.