### PR TITLE
Fix memory order sensitivity of `flowpathextract`

### DIFF
--- a/src/topotoolbox/flow_object.py
+++ b/src/topotoolbox/flow_object.py
@@ -304,12 +304,12 @@ class FlowObject():
         >>> fd = tt3.FlowObject(dem)
         >>> print(fd.flowpathextract(12345))
         """
-        ch = np.zeros(self.shape, dtype=np.uint32, order='F')
-        ch[np.unravel_index(idx, self.shape, order='F')] = 1
+        ch = np.zeros(self.shape, dtype=np.uint32, order=self.order)
+        ch[np.unravel_index(idx, self.shape, order=self.order)] = 1
         edges = np.ones(self.source.size, dtype=np.uint32)
         _stream.traverse_down_u32_or_and(ch, edges, self.source, self.target)
 
-        return np.nonzero(np.ravel(ch, order='F'))[0]
+        return self.stream[ch[np.unravel_index(self.stream, self.shape, order=self.order)] > 0]
 
     def distance(self):
         """Compute the distance between each node in the flow network

--- a/src/topotoolbox/flow_object.py
+++ b/src/topotoolbox/flow_object.py
@@ -71,7 +71,7 @@ class FlowObject():
 
         bc = np.asarray(bc, dtype=np.uint8)
 
-        queue = np.zeros_like(dem, dtype=np.int64)
+        queue = np.zeros(np.prod(dem.shape), dtype=np.int64)
         if hybrid:
             _grid.fillsinks_hybrid(filled_dem, queue, dem, bc, dims)
         else:
@@ -112,6 +112,7 @@ class FlowObject():
         # raster metadata
         self.direction = direction  # dtype=np.unit8
 
+        self.stream = node
         self.source = source[0:edge_count]  # dtype=np.int64
         self.target = target[0:edge_count]  # dtype=np.int64
 

--- a/tests/test_flow_object.py
+++ b/tests/test_flow_object.py
@@ -186,19 +186,18 @@ def test_flowpathextract_order(order_dems):
     cfd = topo.FlowObject(cdem)
     ffd = topo.FlowObject(fdem)
 
-    for ci in np.arange(np.prod(cdem.shape)):
-        # Convert the row-major linear index to column-major
-        fi = np.ravel_multi_index(np.unravel_index(ci, cfd.shape, order=cfd.order),
-                                  ffd.shape, order=ffd.order)
+    # Convert the row-major linear index to column-major
+    ci = np.ravel_multi_index((37, 109), cfd.shape, order=cfd.order)
+    fi = np.ravel_multi_index((37, 109), ffd.shape, order=ffd.order)
 
-        cp = cfd.flowpathextract(ci)
-        fp = ffd.flowpathextract(fi)
+    cp = cfd.flowpathextract(ci)
+    fp = ffd.flowpathextract(fi)
 
-        # Convert the column-major flow path indices to row-major
-        fpc = np.ravel_multi_index(np.unravel_index(fp, ffd.shape, order=ffd.order),
+    # Convert the column-major flow path indices to row-major
+    fpc = np.ravel_multi_index(np.unravel_index(fp, ffd.shape, order=ffd.order),
                                    cfd.shape, order= cfd.order)
 
-        assert np.array_equal(cp, fpc)
+    assert np.array_equal(cp, fpc)
 
 
 def test_imposemin(wide_dem):

--- a/tests/test_flow_object.py
+++ b/tests/test_flow_object.py
@@ -180,6 +180,26 @@ def test_flowpathextract(wide_dem):
     idxs = fd.flowpathextract(s.stream[ch][0])
     assert np.array_equal(s2.stream, idxs)
 
+def test_flowpathextract_order(order_dems):
+    cdem, fdem = order_dems
+
+    cfd = topo.FlowObject(cdem)
+    ffd = topo.FlowObject(fdem)
+
+    for ci in np.arange(np.prod(cdem.shape)):
+        # Convert the row-major linear index to column-major
+        fi = np.ravel_multi_index(np.unravel_index(ci, cfd.shape, order=cfd.order),
+                                  ffd.shape, order=ffd.order)
+
+        cp = cfd.flowpathextract(ci)
+        fp = ffd.flowpathextract(fi)
+
+        # Convert the column-major flow path indices to row-major
+        fpc = np.ravel_multi_index(np.unravel_index(fp, ffd.shape, order=ffd.order),
+                                   cfd.shape, order= cfd.order)
+
+        assert np.array_equal(cp, fpc)
+
 
 def test_imposemin(wide_dem):
     original_dem = wide_dem.z.copy()


### PR DESCRIPTION
See #199

This PR adds a test to make sure that `flowpathextract` returns the same flow path regardless of the memory order of the input DEMs. 

To fix this test, we thread the memory order through the intermediate arrays. However, the result is still sensitive to the memory order because the return value is sorted according to pixel index. We now return a topologically sorted flow path, which is done by indexing through a new `FlowObject.stream` array. This is the counterpart of `StreamObject.stream`, and it contains the linear indices of every pixel in topological order. The topologically sorted return value is now also consistent with the MATLAB implementation, which constructs the flow path by iterating over the edge list.

This change breaks the existing `flowpathextract` test, because the `flowpathextract` return value is now topologically sorted while the `StreamObject.stream` array is not. Since the latter is not topologically sorted in the MATLAB implementation, I left that alone and instead modified the `flowpathextract` test to reconstruct the topological order of the `stream` array.