### PR TITLE
Add memory order test for StreamObject.ezgetnal

### DIFF
--- a/src/topotoolbox/stream_object.py
+++ b/src/topotoolbox/stream_object.py
@@ -81,6 +81,7 @@ class StreamObject():
         self.cellsize = flow.cellsize
         self.shape = flow.shape
         self.strides = flow.strides
+        self.order = flow.order
 
         # georeference
         self.bounds = flow.bounds
@@ -281,16 +282,19 @@ class StreamObject():
                 # k is a GridObject or ndarray with the right shape
                 # and georeferencing
                 # Advanced indexing of k will always return a copy
-                nal = k[np.unravel_index(self.stream, self.shape, order='F')]
+                idxs = np.unravel_index(self.stream, self.shape,
+                                        order=self.order)
+                nal = k[idxs]
 
-                # We use copy=False in astype to avoid copying that copy if possible
+                # We use copy=False in astype to avoid copying that copy
+                # if possible
                 nal = nal.astype(dtype or nal.dtype, copy=False)
             elif hasattr(k, "shape") and self.stream.shape == k.shape:
                 # k is already a node attribute list
                 nal = np.array(k, dtype=dtype, copy=True)
             else:
-                raise ValueError(
-                    f"{k} is not a node attribute list of the appropriate shape.")
+                raise ValueError(f"""{k} is not a node attribute list
+                of the appropriate shape.""")
 
         return nal
 
@@ -390,12 +394,12 @@ class StreamObject():
 
     def to_geodataframe(self):
         '''Convert the stream network to a GeoDataFrame.
-            
+
         Returns
         ----------
         geopandas.GeoDataFrame
             The GeoDataFrame.
- 
+
         Example
         -------
         dem = tt3.load_dem('bigtujunga')
@@ -410,12 +414,12 @@ class StreamObject():
 
     def to_shapefile(self, path: str) -> None:
         '''Convert the stream network to a georeferenced shapefile.
-        
+
         Parameters
         ----------
         path : str
              path where the shapefile will be saved.
-        
+
         Example
         -------
         dem = tt3.load_dem('bigtujunga')

--- a/tests/test_stream_object.py
+++ b/tests/test_stream_object.py
@@ -227,6 +227,28 @@ def test_ezgetnal(tall_dem):
     # ezgetnal with the dtype argument should return array of that type
     assert z3.dtype is np.dtype(np.float64)
 
+
+def test_ezgetnal_order(order_dems):
+    cdem, fdem = order_dems
+
+    cfd = topo.FlowObject(cdem)
+    ffd = topo.FlowObject(fdem)
+
+    cs = topo.StreamObject(cfd)
+    fs = topo.StreamObject(ffd)
+
+    cz = cs.ezgetnal(cdem)
+    fz = fs.ezgetnal(fdem)
+
+    cdz = np.zeros(cs.shape)
+    fdz = np.zeros(fs.shape)
+
+    cdz[np.unravel_index(cs.stream, cs.shape, order=cfd.order)] = cz
+    fdz[np.unravel_index(fs.stream, fs.shape, order=ffd.order)] = fz
+
+    assert np.array_equal(cdz, fdz)
+
+
 def test_subgraph(tall_dem, wide_dem):
     ############
     # Tall DEM #


### PR DESCRIPTION
See #199

This requires storing the memory order of the `stream` member, derived from the `FlowObject`, and passing that memory order to `np.unravel_index` when indexing with `stream`.