### PR TITLE
Hide the memory ordering from users of StreamObject

### DIFF
--- a/src/topotoolbox/stream_object.py
+++ b/src/topotoolbox/stream_object.py
@@ -81,7 +81,7 @@ class StreamObject():
         self.cellsize = flow.cellsize
         self.shape = flow.shape
         self.strides = flow.strides
-        self.order = flow.order
+        self._order = flow.order
 
         # georeference
         self.bounds = flow.bounds
@@ -208,6 +208,83 @@ class StreamObject():
         self.path = flow.path
         self.name = flow.name
 
+    @property
+    def node_indices(self) -> tuple[np.ndarray, np.ndarray]:
+        """The row and column indices of the nodes of the stream
+        network.
+
+        Returns
+        -------
+        tuple of ndarray
+            A tuple of arrays containing the row indices and column
+        indices for the nodes in the stream network. Each of these
+        arrays is a node attribute lists and have a length equal to
+        the number of nodes in the stream network. This tuple of
+        arrays is suitable for indexing GridObjects or arrays shaped
+        like the GridObject from which this StreamObject was derived.
+
+        """
+        return np.unravel_index(self.stream, self.shape, self._order)
+
+    def node_indices_where(self, nal: np.ndarray) -> tuple[np.ndarray,
+                                                           np.ndarray]:
+        """The row and column indices of the nodes of the stream
+        network where a condition is satisfied.
+
+        Returns
+        -------
+        tuple of ndarray
+            A tuple of arrays containing the row indices and column
+        indices for the nodes in the stream network where the input
+        Boolean node attribute list `nal` is true. Each of these
+        arrays is a node attribute lists and have a length equal to
+        the number of nodes in the stream network. This tuple of
+        arrays is suitable for indexing GridObjects or arrays shaped
+        like the GridObject from which this StreamObject was derived.
+
+        """
+        return np.unravel_index(self.stream[nal], self.shape, self._order)
+
+    @property
+    def source_indices(self) -> tuple[np.ndarray, np.ndarray]:
+        """The row and column indices of the sources of each edge in
+        the stream network.
+
+        Returns
+        -------
+        tuple of ndarray
+            A tuple of arrays containing the row indices and column
+        indices of the sources of each edge in the stream
+        network. Each of these arrays is an edge attribute lists and
+        have a length equal to the number of edges in the stream
+        network. This tuple of arrays is suitable for indexing
+        GridObjects or arrays shaped like the GridObject from which
+        this StreamObject was derived.
+
+        """
+        return np.unravel_index(self.stream[self.source],
+                                self.shape, self._order)
+
+    @property
+    def target_indices(self) -> tuple[np.ndarray, np.ndarray]:
+        """The row and column indices of the targets of each edge in
+        the stream network.
+
+        Returns
+        -------
+        tuple of ndarray
+            A tuple of arrays containing the row indices and column
+        indices of the sources of each edge in the stream
+        network. Each of these arrays is an edge attribute lists and
+        have a length equal to the number of edges in the stream
+        network. This tuple of arrays is suitable for indexing
+        GridObjects or arrays shaped like the GridObject from which
+        this StreamObject was derived.
+
+        """
+        return np.unravel_index(self.stream[self.target],
+                                self.shape, self._order)
+
     def distance(self) -> np.ndarray:
         """
         Compute the pixel-to-pixel distance for each edge.
@@ -282,9 +359,7 @@ class StreamObject():
                 # k is a GridObject or ndarray with the right shape
                 # and georeferencing
                 # Advanced indexing of k will always return a copy
-                idxs = np.unravel_index(self.stream, self.shape,
-                                        order=self.order)
-                nal = k[idxs]
+                nal = k[self.node_indices]
 
                 # We use copy=False in astype to avoid copying that copy
                 # if possible
@@ -351,7 +426,7 @@ class StreamObject():
         """
         if data is None:
             # pylint: disable=unbalanced-tuple-unpacking
-            j, i = np.unravel_index(self.stream, self.shape, order='F')
+            j, i = self.node_indices
             xs, ys = self.transform * np.vstack((i, j))
         else:
             xs, ys = data

--- a/tests/test_stream_object.py
+++ b/tests/test_stream_object.py
@@ -149,8 +149,8 @@ def test_distance_order(order_dems):
     cdg = np.zeros(cfd.shape)
     fdg = np.zeros(ffd.shape)
 
-    cdg[np.unravel_index(cs.stream[cs.source], cs.shape, order=cfd.order)] = cd
-    fdg[np.unravel_index(fs.stream[fs.source], fs.shape, order=ffd.order)] = fd
+    cdg[cs.source_indices] = cd
+    fdg[fs.source_indices] = fd
 
     assert np.array_equal(cdg, fdg)
 
@@ -169,8 +169,8 @@ def test_downstream_distance_order(order_dems):
     cdg = np.zeros(cfd.shape)
     fdg = np.zeros(ffd.shape)
 
-    cdg[np.unravel_index(cs.stream, cs.shape, order=cfd.order)] = cd
-    fdg[np.unravel_index(fs.stream, fs.shape, order=ffd.order)] = fd
+    cdg[cs.node_indices] = cd
+    fdg[fs.node_indices] = fd
 
     assert np.array_equal(cdg, fdg)
 
@@ -263,8 +263,8 @@ def test_ezgetnal_order(order_dems):
     cdz = np.zeros(cs.shape)
     fdz = np.zeros(fs.shape)
 
-    cdz[np.unravel_index(cs.stream, cs.shape, order=cfd.order)] = cz
-    fdz[np.unravel_index(fs.stream, fs.shape, order=ffd.order)] = fz
+    cdz[cs.node_indices] = cz
+    fdz[fs.node_indices] = fz
 
     assert np.array_equal(cdz, fdz)
 
@@ -289,13 +289,13 @@ def test_streampoi_order(order_dems):
     cp = np.zeros(cs.shape, dtype=np.uint32)
     fp = np.zeros(fs.shape, dtype=np.uint32)
 
-    cp[np.unravel_index(cs.stream[ch], cs.shape, order=cs.order)] |= 1
-    cp[np.unravel_index(cs.stream[co], cs.shape, order=cs.order)] |= 2
-    cp[np.unravel_index(cs.stream[cc], cs.shape, order=cs.order)] |= 4
+    cp[cs.node_indices_where(ch)] |= 1
+    cp[cs.node_indices_where(co)] |= 2
+    cp[cs.node_indices_where(cc)] |= 4
 
-    fp[np.unravel_index(fs.stream[fh], fs.shape, order=fs.order)] |= 1
-    fp[np.unravel_index(fs.stream[fo], fs.shape, order=fs.order)] |= 2
-    fp[np.unravel_index(fs.stream[fc], fs.shape, order=fs.order)] |= 4
+    fp[fs.node_indices_where(fh)] |= 1
+    fp[fs.node_indices_where(fo)] |= 2
+    fp[fs.node_indices_where(fc)] |= 4
 
     assert np.array_equal(cp, fp)
 


### PR DESCRIPTION
The memory ordering is an implementation detail that users really shouldn't have to worry about, especially at the level of the FlowObject and StreamObject. This change makes the StreamObject.order attribute "private" by renaming it to StreamObject._order and provides a few accessor functions for obtaining the indices of nodes and edges in the stream network.

Since numpy does not perform linear indexing, we need to unravel the linear indices before indexing into an array like a GridObject. The accessors do this unraveling and return a tuple of two arrays, one with the row indices, one with the column indices. This tuple can be used to directly index into an array.

The provided accessors are

- StreamObject.node_indices :: the indices of the nodes in the stream network. This is a node attribute list, and it is a property, so it is accessed without the parentheses

- StreamObject.node_indices_where(nal) :: the indices filtered by the Boolean node attribute list. This is a function. It allows you to retrieve the indices of subsets of the nodes, such as outlets, using something like s.node_indices_where(s.streampoi('outlets'))

- StreamObject.source_indices :: the indices of the sources of each edge. This is an edge attribute list and a property.

- StreamObject.target_indices :: the indices of the targets of each edge. This is an edge attribute list and a property.

The unravel_index calls have largely been removed from stream_object.py and test_stream_object.py.