### PR TITLE
Add multidimensional index accessors to FlowObject

### DIFF
--- a/src/topotoolbox/flow_object.py
+++ b/src/topotoolbox/flow_object.py
@@ -174,6 +174,18 @@ class FlowObject():
         """
         return np.unravel_index(self.target, self.shape, self.order)
 
+    def unravel_index(self, idxs: int | np.ndarray) -> tuple[np.ndarray, ...]:
+        """Unravel the provided linear indices so they can be used to
+        index grids.
+
+        Returns
+        -------
+        tuple of ndarray
+            A tuple of arrays containing the row indices and column
+        indices of the sources of each pixel in the idxs array.
+        """
+        return np.unravel_index(idxs, self.shape, self.order)
+
     def ezgetnal(self, k, dtype=None) -> GridObject | np.ndarray:
         """Retrieve a node attribute list
 
@@ -300,7 +312,7 @@ class FlowObject():
             _flow.drainagebasins(basins, self.source, self.target, self.dims)
         else:
             basins = np.zeros(self.shape, dtype=np.uint32, order=self.order)
-            indices = np.unravel_index(outlets, self.shape, order=self.order)
+            indices = self.unravel_index(outlets)
             basins[indices] = np.arange(1, len(outlets) + 1, dtype=np.uint32)
             weights = np.full(self.source.size, 0xffffffff, dtype=np.uint32)
             _stream.traverse_up_u32_or_and(
@@ -343,11 +355,11 @@ class FlowObject():
         >>> print(fd.flowpathextract(12345))
         """
         ch = np.zeros(self.shape, dtype=np.uint32, order=self.order)
-        ch[np.unravel_index(idx, self.shape, order=self.order)] = 1
+        ch[self.unravel_index(idx)] = 1
         edges = np.ones(self.source.size, dtype=np.uint32)
         _stream.traverse_down_u32_or_and(ch, edges, self.source, self.target)
 
-        return self.stream[ch[np.unravel_index(self.stream, self.shape, order=self.order)] > 0]
+        return self.stream[ch[self.unravel_index(self.stream)] > 0]
 
     def distance(self):
         """Compute the distance between each node in the flow network

--- a/src/topotoolbox/flow_object.py
+++ b/src/topotoolbox/flow_object.py
@@ -136,6 +136,44 @@ class FlowObject():
 
         return (self.shape[1], self.shape[0])
 
+    @property
+    def source_indices(self) -> tuple[np.ndarray, ...]:
+        """The row and column indices of the sources of each edge in
+        the flow network.
+
+        Returns
+        -------
+        tuple of ndarray
+            A tuple of arrays containing the row indices and column
+        indices of the sources of each edge in the flow
+        network. Each of these arrays is an edge attribute lists and
+        have a length equal to the number of edges in the flow
+        network. This tuple of arrays is suitable for indexing
+        GridObjects or arrays shaped like the GridObject from which
+        this FlowObject was derived.
+
+        """
+        return np.unravel_index(self.source, self.shape, self.order)
+
+    @property
+    def target_indices(self) -> tuple[np.ndarray, ...]:
+        """The row and column indices of the targets of each edge in
+        the flow network.
+
+        Returns
+        -------
+        tuple of ndarray
+            A tuple of arrays containing the row indices and column
+        indices of the sources of each edge in the flow
+        network. Each of these arrays is an edge attribute lists and
+        have a length equal to the number of edges in the flow
+        network. This tuple of arrays is suitable for indexing
+        GridObjects or arrays shaped like the GridObject from which
+        this FlowObject was derived.
+
+        """
+        return np.unravel_index(self.target, self.shape, self.order)
+
     def ezgetnal(self, k, dtype=None) -> GridObject | np.ndarray:
         """Retrieve a node attribute list
 

--- a/tests/test_flow_object.py
+++ b/tests/test_flow_object.py
@@ -226,8 +226,8 @@ def test_distance_order(order_dems):
     cdg = np.zeros(cfd.shape)
     fdg = np.zeros(ffd.shape)
 
-    cdg[np.unravel_index(cfd.source, cfd.shape, order=cfd.order)] = cd
-    fdg[np.unravel_index(ffd.source, ffd.shape, order=ffd.order)] = fd
+    cdg[cfd.source_indices] = cd
+    fdg[ffd.source_indices] = fd
 
     assert np.array_equal(cdg, fdg)
 
@@ -235,8 +235,8 @@ def test_imposemin(wide_dem):
     original_dem = wide_dem.z.copy()
     fd = topo.FlowObject(wide_dem)
 
-    g0 = (wide_dem.z[np.unravel_index(fd.source, fd.shape, order='F')] -
-          wide_dem.z[np.unravel_index(fd.target, fd.shape, order='F')])/fd.distance()
+    g0 = (wide_dem.z[fd.source_indices] -
+          wide_dem.z[fd.target_indices])/fd.distance()
 
     # Make sure that the test array has slopes less than the imposed minimum
     assert not np.all(g0 >= 0.1 - 1e-6)
@@ -249,8 +249,8 @@ def test_imposemin(wide_dem):
 
         # The gradient along the flow network should be greater than or
         # equal to the defined slope within some numerical error
-        g = (min_dem.z[np.unravel_index(fd.source, fd.shape, order='F')] -
-             min_dem.z[np.unravel_index(fd.target, fd.shape, order='F')])/fd.distance()
+        g = (min_dem.z[fd.source_indices] -
+             min_dem.z[fd.target_indices])/fd.distance()
         assert np.all(g >= minimum_slope - 1e-6)
 
         # imposemin should not modify the original array
@@ -268,8 +268,8 @@ def test_imposemin_f64(wide_dem):
 
     assert np.all(min_dem <= z)
 
-    g = (min_dem[np.unravel_index(fd.source, fd.shape, order='F')] -
-         min_dem[np.unravel_index(fd.target, fd.shape, order='F')])/fd.distance()
+    g = (min_dem[fd.source_indices] -
+         min_dem[fd.target_indices])/fd.distance()
     assert np.all(g >= 0.001 - 1e-6)
 
     # imposemin should not modify the original array

--- a/tests/test_flow_object.py
+++ b/tests/test_flow_object.py
@@ -64,8 +64,8 @@ def test_flowobject_order(order_dems):
 
     # We can construct the isomorphism by recomputing the linear
     # indices of the row-major array in the column-major ordering.
-    idxmap = np.ravel_multi_index(np.unravel_index(
-        np.arange(0, np.prod(cfd.shape)), cfd.shape, order='C'), ffd.shape, order='F')
+    cidxs = cfd.unravel_index(np.arange(0, np.prod(cfd.shape)))
+    idxmap = np.ravel_multi_index(cidxs, ffd.shape, order='F')
 
     # Now test whether the edge sets are identical
     cedges = set(
@@ -209,8 +209,8 @@ def test_flowpathextract_order(order_dems):
     fp = ffd.flowpathextract(fi)
 
     # Convert the column-major flow path indices to row-major
-    fpc = np.ravel_multi_index(np.unravel_index(fp, ffd.shape, order=ffd.order),
-                                   cfd.shape, order= cfd.order)
+    fpc = np.ravel_multi_index(ffd.unravel_index(fp),
+                               cfd.shape, order=cfd.order)
 
     assert np.array_equal(cp, fpc)
 


### PR DESCRIPTION
This PR mirrors #276 for `FlowObject` and more or less resolves #202.

The `source_indices` and `target_indices` properties work just as they do for `StreamObject`. `node_indices` and `node_indices_with` from `StreamObject` are not included because the node indices are just the indices of the `GridObject` in topological order, and I have not found an application of these yet.

There is also a `FlowObject.unravel_index` method that takes linear indices from the user and unravels them according to the shape and memory order of the `FlowObject`. This is just a wrapper around Numpy's `unravel_index` function. I'm not sure that it is exactly necessary, but there are several places in the `FlowObject` methods and in the tests that this is necessary. I did not implement the inverse, `ravel_multi_index`, because there are only a few locations in the tests where this is used.