### PR TITLE
Add resize and zscore

### DIFF
--- a/src/topotoolbox/grid_object.py
+++ b/src/topotoolbox/grid_object.py
@@ -1252,6 +1252,12 @@ class GridObject():
         result.z = (self.z - np.nanmean(self.z)) / np.nanstd(self.z)
         return result
 
+    def castshadows(self, azimuth, altitude) -> 'GridObject':
+        pass
+
+    def impaintnans():
+        pass
+
         # 'Magic' functions:
         # ------------------------------------------------------------------------
 

--- a/src/topotoolbox/grid_object.py
+++ b/src/topotoolbox/grid_object.py
@@ -170,7 +170,8 @@ class GridObject():
             dst.cellsize = abs(dst.transform[0])
 
         if self.bounds:
-            dst.bounds = BoundingBox(*transform_bounds(self.crs, dst.crs, *self.bounds))
+            dst.bounds = BoundingBox(
+                *transform_bounds(self.crs, dst.crs, *self.bounds))
 
         return dst
 
@@ -270,7 +271,7 @@ class GridObject():
         if output is None:
             output = ['sills', 'flats']
 
-        dem = np.asarray(self,dtype=np.float32)
+        dem = np.asarray(self, dtype=np.float32)
         output_grid = np.zeros_like(dem, dtype=np.int32)
 
         _grid.identifyflats(output_grid, dem, self.dims)
@@ -835,7 +836,8 @@ class GridObject():
         prominence_array = np.array(prominence)
         indices_array = np.array(indices)
         indices_array = indices_array[:, [1, 0]]  # swap columns 0 and 1
-        indices_array = indices_array.T  # transpose to get (x, y) instead of (y, x)
+        # transpose to get (x, y) instead of (y, x)
+        indices_array = indices_array.T
         return prominence_array, indices_array
 
     def hillshade(self,
@@ -896,7 +898,7 @@ class GridObject():
         dx, dy = ~gt * (sx, sy)
 
         # And retrieve the azimuth angle.
-        azimuth_radians = np.arctan2(dy,dx)
+        azimuth_radians = np.arctan2(dy, dx)
 
         # NOTE(wkearn): This angle is then immediately used within
         # hillshade to compute vector components again. It would be
@@ -1056,8 +1058,8 @@ class GridObject():
     def plot_hs(self, ax=None,
                 elev=None,
                 azimuth=315, altitude=60, exaggerate=1,
-                filter_method=None, filter_size = 3,
-                cmap='terrain', norm = None,
+                filter_method=None, filter_size=3,
+                cmap='terrain', norm=None,
                 blend_mode='soft',
                 extent=None,
                 **kwargs):
@@ -1141,16 +1143,17 @@ class GridObject():
             raise TypeError(err) from None
 
         if filter_method is not None:
-            shade = shade.filter(method=filter_method,kernelsize=filter_size)
+            shade = shade.filter(method=filter_method, kernelsize=filter_size)
 
         h = shade.hillshade(azimuth, altitude, exaggerate)
         cmap = plt.get_cmap(cmap)
 
         if norm is None:
-            norm = colors.Normalize(vmin=np.nanmin(self.z),vmax=np.nanmax(self.z))
+            norm = colors.Normalize(vmin=np.nanmin(
+                self.z), vmax=np.nanmax(self.z))
 
         base = cmap(norm(self.z))
-        top = np.expand_dims(np.clip(h,0,1),2)
+        top = np.expand_dims(np.clip(h, 0, 1), 2)
         if blend_mode == "multiply":
             rgb = base * top
         elif blend_mode == "overlay":
@@ -1163,7 +1166,7 @@ class GridObject():
         if extent is None:
             extent = self.extent
 
-        return ax.imshow(np.clip(rgb,0,1), extent=extent, **kwargs)
+        return ax.imshow(np.clip(rgb, 0, 1), extent=extent, **kwargs)
 
     def shufflelabel(self, seed=None):
         """Randomize the labels of a GridObject
@@ -1198,7 +1201,7 @@ class GridObject():
 
         return result
 
-    def duplicate_with_new_data(self, data : np.ndarray) -> 'GridObject':
+    def duplicate_with_new_data(self, data: np.ndarray) -> 'GridObject':
         """Duplicate a GridObject with different data
 
         This function is helpful when one wants to create a GridObject from
@@ -1229,8 +1232,28 @@ class GridObject():
 
         return result
 
-    # 'Magic' functions:
-    # ------------------------------------------------------------------------
+    def zscore(self):
+        """Returns the z-score for each element of GridObject such that 
+        all values are centered to have mean 0 and scaled to have 
+        standard deviation 1.
+
+        Returns
+        -------
+        GridObject
+            A GridObject containing the z-scores of the input GridObject.
+
+        Example
+        -------
+        >>> dem = topotoolbox.load_dem('tibet')
+        >>> dem_zscore = dem.zscore()
+        >>> dem_zscore.plot()
+        """
+        result = cp.copy(self)
+        result.z = (self.z - np.nanmean(self.z)) / np.nanstd(self.z)
+        return result
+
+        # 'Magic' functions:
+        # ------------------------------------------------------------------------
 
     def __eq__(self, other):
         dem = cp.deepcopy(self)
@@ -1433,7 +1456,6 @@ class GridObject():
 
     def __str__(self):
         return str(self.z)
-
 
     def __repr__(self):
 

--- a/src/topotoolbox/grid_object.py
+++ b/src/topotoolbox/grid_object.py
@@ -1252,12 +1252,6 @@ class GridObject():
         result.z = (self.z - np.nanmean(self.z)) / np.nanstd(self.z)
         return result
 
-    def castshadows(self, azimuth, altitude) -> 'GridObject':
-        pass
-
-    def impaintnans():
-        pass
-
         # 'Magic' functions:
         # ------------------------------------------------------------------------
 

--- a/src/topotoolbox/grid_object.py
+++ b/src/topotoolbox/grid_object.py
@@ -21,6 +21,7 @@ from scipy.signal import wiener
 
 from rasterio import CRS, Affine
 from rasterio.coords import BoundingBox
+from rasterio.transform import array_bounds
 from rasterio.warp import reproject, transform_bounds
 from rasterio.enums import Resampling
 
@@ -1233,8 +1234,8 @@ class GridObject():
         return result
 
     def zscore(self):
-        """Returns the z-score for each element of GridObject such that 
-        all values are centered to have mean 0 and scaled to have 
+        """Returns the z-score for each element of GridObject such that
+        all values are centered to have mean 0 and scaled to have
         standard deviation 1.
 
         Returns
@@ -1250,6 +1251,135 @@ class GridObject():
         """
         result = cp.copy(self)
         result.z = (self.z - np.nanmean(self.z)) / np.nanstd(self.z)
+        return result
+
+    def resize(self, left: float | int, right: float | int, 
+               top: float | int, bottom: float | int, 
+               highlight_selected: bool=False) -> 'GridObject':
+        """Resize the Gridobject by cropping to specified boundaries.
+
+        Supports three input modes (percentage, coordinate, pixel) to define
+        the crop region. Automatically detects the mode based on input values.
+        In case of reversed boundaries, automatically swaps them to ensure
+        the crop region is valid. If coordinate and pixel modes include the
+        same values, the coordinate mode takes precedence.
+        The resulting grid will have a new transform and bounds based on the
+        specified boundaries. If `highlight_selected` is True, the original
+        grid will be plotted with the selected region highlighted.
+
+        Parameters
+        ----------
+        left : float or int
+            Left boundary in one of three modes:
+            - Percentage: 0.0 to 1.0 (relative to grid width)
+            - Coordinate: Within grid's horizontal bounds
+            - Pixel: Column index (0 to grid width-1)
+        right : float or int
+            Right boundary (same modes as `left`).
+        top : float or int
+            Top boundary in one of three modes:
+            - Percentage: 0.0-1.0 (relative to grid height)
+            - Coordinate: Within grid's vertical bounds
+            - Pixel: Row index (0 to grid height-1)
+        bottom : float or int
+            Bottom boundary (same modes as `top`).
+        highlight_selected : bool, optional, default=False
+            If True, plots the original grid with selected region highlighted.
+
+        Returns
+        -------
+        GridObject
+            Cropped grid with updated transform, bounds, and data.
+
+        Raises
+        ------
+        ValueError
+            If boundaries are not in a consistent valid mode.
+
+        Example
+        -------
+        >>> dem = topotoolbox.load_dem('tibet')
+        >>> new_dem = dem.resize(0.6, 0.8, 0.3, 0.5, highlight_selected=True)
+        >>> new_dem = dem.resize(240000, 300000, 2600000, 2500000, 
+                                 highlight_selected=True)
+        >>> new_dem = dem.resize(1000, 1500, 600, 1100, 
+                                 highlight_selected=True)
+        >>> new_dem.plot()
+        """
+        height, width = self.shape[0], self.shape[1]
+        # Case 1: Percentage mode (all values between 0 and 1)
+        if all(0.0 <= float(val) <= 1.0 for val in [top, bottom, left, right]):
+            y_start = int(top * height)
+            y_end = int(bottom * height)
+            x_start = int(left * width)
+            x_end = int(right * width)
+
+        # Case 2: Coordinate mode
+        elif (all(self.bounds.left <= val <= self.bounds.right for 
+                  val in [left, right]) and
+              all(self.bounds.bottom <= val <= self.bounds.top for 
+                  val in [top, bottom])):
+            y_start = int((self.bounds.top - top) / self.cellsize)
+            y_end = int((self.bounds.top - bottom) / self.cellsize)
+            x_start = int((left - self.bounds.left) / self.cellsize)
+            x_end = int((right - self.bounds.left) / self.cellsize)
+
+        # Case 3: Pixel mode (values are in array indices)
+        elif (all(0 <= val < height for val in [top, bottom]) and
+              all(0 <= val < width for val in [left, right])):
+            y_start, y_end = int(top), int(bottom)
+            x_start, x_end = int(left), int(right)
+
+        else:
+            err = ("Provided Borders are not in a valid format."
+                   " Please provide values in one of the following formats:\n"
+                   "1. Percentage mode: all values between 0.0 and 1.0\n"
+                   "2. Coordinate mode: all values within the extent of the "
+                   f"GridObject: extent = {self.extent}\n"
+                   "3. Pixel mode: all values are valid indices of the "
+                   f"GridObject: 0 to {self.shape[0]} for rows and 0 to "
+                   f"{self.shape[1]} for columns.")
+            raise ValueError(err) from None
+
+        # Ensure x_start < x_end and y_start < y_end to handle switched
+        # bounds instead of raising an error
+        if x_start > x_end:
+            x_start, x_end = x_end, x_start
+        if y_start > y_end:
+            y_start, y_end = y_end, y_start
+
+        result = cp.copy(self)
+
+        # Calculate new transform
+        new_x_origin = self.transform.c + x_start * self.transform.a
+        new_y_origin = self.transform.f + y_start * self.transform.e
+        new_transform = Affine(
+            self.transform.a, self.transform.b, new_x_origin,
+            self.transform.d, self.transform.e, new_y_origin)
+        result.transform = new_transform
+        # Calculate new bounds
+        new_left = new_x_origin
+        new_top = new_y_origin
+        new_right = new_x_origin + (x_end - x_start) * self.transform.a
+        new_bottom = new_y_origin + (y_end - y_start) * self.transform.e
+        new_bounds = BoundingBox(new_left, new_bottom, new_right, new_top)
+        result.bounds = new_bounds
+        # Crop DEM
+        result.z = result.z[y_start:y_end, x_start:x_end]
+
+        if highlight_selected:
+            _, ax = plt.subplots()
+            # adjust selection rectangle to extent
+            x_start = self.bounds.left + x_start * self.cellsize
+            x_end = self.bounds.left + x_end * self.cellsize
+            y_start = self.bounds.top - y_start * self.cellsize
+            y_end = self.bounds.top - y_end * self.cellsize
+            # plot rectangle
+            x = [x_start, x_end, x_end, x_start, x_start]
+            y = [y_start, y_start, y_end, y_end, y_start]
+            self.plot()
+            ax.plot(x, y, 'r-', linewidth=2)
+
         return result
 
         # 'Magic' functions:


### PR DESCRIPTION
This adds the functions `zscore` and `resize` to the `GridObject`.

Maybe `crop` would be a more fitting name for the `resize` function. Also, having the arguments `left`, `right`, `top` and `bottom` might be unnecessary. The function only needs two x and y values each and figures out which is left/right or top/bottom automatically. Using `highlight_selected` will create a plot which highlights the area the new `GridObject` will be cropped to. 
I am not 100% sure the updating of the bounds and transform is completely correct, so if anything seems off about that please let me know.
Closes #264