### PR TITLE
Add a memory order test for GridObject.reproject

### DIFF
--- a/src/topotoolbox/grid_object.py
+++ b/src/topotoolbox/grid_object.py
@@ -176,7 +176,7 @@ class GridObject():
         """
         dst = GridObject()
 
-        dst.z, dst.transform = reproject(
+        z, dst.transform = reproject(
             self.z,
             src_transform=self.transform,
             src_crs=self.crs,
@@ -186,9 +186,9 @@ class GridObject():
             dst_resolution=resolution,
             resampling=resampling,
         )
-        # reproject gives us a 3D array, we want the first band
-        # We also want it in column-major order
-        dst.z = np.asfortranarray(dst.z[0, :, :])
+        # reproject gives us a 3D array, we want the first band.
+        dst.z = np.zeros_like(self.z, shape=z.shape[1:3])
+        dst.z[:, :] = z[0, :, :]
 
         dst.crs = crs
 

--- a/tests/test_grid_object.py
+++ b/tests/test_grid_object.py
@@ -33,13 +33,13 @@ def order_dems():
     cdem.z = np.array(
         64 * (opensimplex.noise2array(x/13, y/13) + 1), dtype=np.float32)
     cdem.cellsize = 13.0
-    cdem.transform = Affine.scale(cdem.cellsize)
+    cdem.transform = Affine.permutation() * Affine.rotation(90) * Affine.scale(cdem.cellsize)
     cdem.crs = CRS.from_epsg(3857)
 
     fdem = topo.GridObject()
     fdem.z = np.asfortranarray(cdem.z)
     fdem.cellsize = 13.0
-    fdem.transform = Affine.rotation(180) * Affine.scale(fdem.cellsize)
+    fdem.transform = Affine.permutation() * Affine.rotation(90) * Affine.scale(fdem.cellsize)
     fdem.crs = CRS.from_epsg(3857)
 
     return [cdem, fdem]


### PR DESCRIPTION
See #199 

This did require some modifications to `reproject` to make sure that it returns an array with the same memory order as the source array. The tests also required changing the geotransforms of the two `order_dems`.