### PR TITLE
Pin Python 3.13 to 3.13.5 on CI.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,6 @@
 name: CI
 on:
-  pull_request:    
+  pull_request:
   push:
     branches: ["main"]
 jobs:
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.10', '3.11', '3.12', '3.13.5']
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
There is a problem with C extensions on 3.13.4 that is fixed in 3.13.5.