### PR TITLE
Implement lowerenv

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ include(FetchContent)
 FetchContent_Declare(
   topotoolbox
   GIT_REPOSITORY https://github.com/TopoToolbox/libtopotoolbox.git
-  GIT_TAG 06a675460cdb29c9c0b57bd2705958949caac0cb
+  GIT_TAG 1084fc42c4e8428829d56e5f3d3c18cea3d6a906
 )
 FetchContent_MakeAvailable(topotoolbox)
 

--- a/src/lib/stream.cpp
+++ b/src/lib/stream.cpp
@@ -198,6 +198,22 @@ void wrap_propagatevaluesupstream_i64(py::array_t<int64_t> data,
                               source.size());
 }
 
+void wrap_lowerenv(py::array_t<float> elevation,
+                   py::array_t<uint8_t> knickpoints,
+                   py::array_t<float> distance,
+                   py::array_t<ptrdiff_t> ix,
+                   py::array_t<uint8_t> onenvelope,
+                   py::array_t<ptrdiff_t> source,
+                   py::array_t<ptrdiff_t> target) {
+
+  ptrdiff_t node_count = elevation.size();
+  ptrdiff_t edge_count = source.size();
+
+  lowerenv(elevation.mutable_data(), knickpoints.mutable_data(), distance.mutable_data(),
+           ix.mutable_data(), onenvelope.mutable_data(), source.mutable_data(),
+           target.mutable_data(), edge_count, node_count);
+}
+
 PYBIND11_MODULE(_stream, m) {
   m.def("streamquad_trapz_f32", &wrap_streamquad_trapz_f32);
   m.def("streamquad_trapz_f64", &wrap_streamquad_trapz_f64);
@@ -211,4 +227,5 @@ PYBIND11_MODULE(_stream, m) {
   m.def("edgelist_degree", &wrap_edgelist_degree);
   m.def("propagatevaluesupstream_u8", &wrap_propagatevaluesupstream_u8);
   m.def("propagatevaluesupstream_i64", &wrap_propagatevaluesupstream_i64);
+  m.def("lowerenv", &wrap_lowerenv);
 }

--- a/src/topotoolbox/stream_object.py
+++ b/src/topotoolbox/stream_object.py
@@ -1316,6 +1316,60 @@ class StreamObject():
 
         return zs
 
+    def lowerenv(self, dem: GridObject | np.ndarray, kn: np.ndarray) -> np.ndarray:
+        """Compute the lower convex envelope of a stream profile
+
+        Parameters
+        ----------
+        dem: GridObject or np.ndarray
+
+            The elevation data of the stream network provided either
+            as a GridObject compatible with this StreamObject or as a
+            node attribute list. The elevation data should be
+            decreasing downstream. Preprocess with imposemin or
+            quantcarve if necessary.
+
+        kn: np.ndarray
+            A logical node attribute list that is true for nodes that
+            should be considered knickpoints, where the stream profile
+            need not be convex.
+
+        Returns
+        -------
+        np.ndarray
+            A node attribute list containing the elevation of the
+            smoothed profile.
+
+        Example
+        -------
+        >>> import numpy as np
+        >>> import matplotlib.pyplot as plt
+        >>> dem = topotoolbox.load_dem('bigtujunga')
+        >>> fd = topotoolbox.FlowObject(dem)
+        >>> s = topotoolbox.StreamObject(fd)
+        >>> s = s.klargestconncomps(1)
+        >>> z = topotoolbox.imposemin(s, dem)
+        >>> kn = np.zeros(len(z), dtype=np.bool)
+        >>> ze = s.lowerenv(z, kn)
+        >>> fig,ax = plt.subplots()
+        >>> s.plotdz(dem, ax=ax, color='gray')
+        >>> s.plotdz(ze, ax=ax, color='black')
+        >>> ax.autoscale_view()
+
+        """
+        z = self.ezgetnal(dem, dtype=np.float32)
+        d = self.upstream_distance()
+
+        nv = len(z)
+        ix = np.zeros(nv, dtype=np.int64)
+        onenvelope = np.zeros(nv, dtype=np.uint8)
+
+        _stream.lowerenv(z, kn.astype(np.uint8),
+                         d, ix, onenvelope,
+                         self.source, self.target)
+
+        return z
+
     # 'Magic' functions:
     # ------------------------------------------------------------------------
 


### PR DESCRIPTION
Resolves #305
Resolves #306

This PR implements lowerenv, which computes the lower convex envelope of a stream profile. It relies on the libtopotoolbox function of the same name (TopoToolbox/libtopotoolbox#196).

CMakeLists.txt is updated with the tag of libtopotoolbox that includes lowerenv.

src/lib/stream.cpp wraps lowerenv.

src/topotoolbox/stream_object.py implements lowerenv as a method on StreamObject.

tests/test_stream_object.py adds a property-based test of convexity of the profile. This is the same property-based test used in the libtopotoolbox test suite. It also adds a memory ordering test (#199).