### PR TITLE
Implement conncomps

### DIFF
--- a/src/topotoolbox/stream_object.py
+++ b/src/topotoolbox/stream_object.py
@@ -774,6 +774,25 @@ class StreamObject():
         result = self.subgraph(trunks)
         return result
 
+    def conncomps(self) -> np.ndarray:
+        """Label connected components in a stream network
+
+        Returns
+        -------
+        np.ndarray
+           A node attribute list containing the labels of each
+           connected component. The labels range from 1 to the number
+           of connected components in the network.
+        """
+        outlets = self.streampoi('outlets')
+
+        l = np.zeros(self.stream.size, dtype=np.int64)
+        l[outlets] = np.arange(np.count_nonzero(outlets)) + 1
+
+        _stream.propagatevaluesupstream_i64(l, self.source, self.target)
+
+        return l
+
     def klargestconncomps(self, k=1) -> 'StreamObject':
         """Extract the k largest connected components of the stream network
 


### PR DESCRIPTION
This is very similar to computing drainage basins: we label each component at the outlet and then propagate those labels upstream.

test_conncomps ensures that each node has the same label as its downstream neighbor and checks that the labels are reasonable. Note that we have to clean the StreamObject to ensure that there are no single-pixel networks, which don't get labeled properly.

test_conncomps_order is a standard memory order test (#199), but it does have to account for differences in the labels. We do this in our FlowObject drainage basins test, and this code is copied from there.