### PR TITLE
Add a missing comma to the OPEN_TOPO_DATASETS variable

### DIFF
--- a/src/topotoolbox/utils.py
+++ b/src/topotoolbox/utils.py
@@ -20,7 +20,7 @@ __all__ = ["load_dem", "get_dem_names", "read_tif", "gen_random", "write_tif",
 DEM_SOURCE = "https://raw.githubusercontent.com/TopoToolbox/DEMs/master"
 DEM_NAMES = f"{DEM_SOURCE}/dem_names.txt"
 OPEN_TOPO_SOURCE = "https://portal.opentopography.org/API/globaldem"
-OPEN_TOPO_DATASETS = ('SRTMGL3', 'SRTMGL1', 'SRTMGL1_E', 'AW3D30', 'AW3D30_E'
+OPEN_TOPO_DATASETS = ('SRTMGL3', 'SRTMGL1', 'SRTMGL1_E', 'AW3D30', 'AW3D30_E',
                       'SRTM15Plus', 'NASADEM', 'COP30', 'COP90', 'EU_DTM',
                       'GEDI_L3', 'GEBCOIceTopo', 'GEBCOSubIceTopo',
                       'CA_MRDEM_DTM', 'CA_MRDEM_DSM')


### PR DESCRIPTION
'AW3D30_E' and 'SRTM15Plus' are concatenated into one dataset that doesn't exist, and, because we check this before calling the OpenTopography API, we can't access either of these data sets.