### PR TITLE
Rename georef -> crs in to_geodataframe

### DIFF
--- a/src/topotoolbox/stream_object.py
+++ b/src/topotoolbox/stream_object.py
@@ -496,7 +496,7 @@ class StreamObject():
         '''
 
         line_geoms = [LineString(coords) for coords in self.xy()]
-        gdf = gpd.GeoDataFrame(geometry=line_geoms, georef=self.georef)
+        gdf = gpd.GeoDataFrame(geometry=line_geoms, crs=self.georef)
         return gdf
 
     def to_shapefile(self, path: str) -> None:

--- a/tests/test_stream_object.py
+++ b/tests/test_stream_object.py
@@ -815,3 +815,7 @@ def test_knickpoints_kpcopy(wide_dem):
     assert np.array_equal(kp_copy, kp0)
 
     assert np.count_nonzero(kp) >= np.count_nonzero(kp0)
+
+
+def test_togeodataframe(wide_stream):
+    wide_stream.to_geodataframe()


### PR DESCRIPTION
This should not have been changed in #318, but it was missed because we don't currently have any tests that run this code. This PR also adds a smoke test.