### PR TITLE
Fix rendering of LaTeX in chi maps tutorial

### DIFF
--- a/docs/tutorial/stream.ipynb
+++ b/docs/tutorial/stream.ipynb
@@ -112,7 +112,7 @@
     "\n",
     "In a $\\chi$ transformation, the distance upstream of a river is replaced by a reference that factors in its total and upstream drainage area and the concavity of the stream:\n",
     "\n",
-    "$\\chi = \\int{ \\frac{A_0}{A(x)^{m/n}}} dx $\n",
+    "$\\chi = \\int{ \\frac{A_0}{A(x)^{m/n}}} dx$\n",
     "\n",
     "More info in this blogpost: https://topotoolbox.wordpress.com/2017/08/18/chimaps-in-a-few-lines-of-code-final/\n",
     "\n",
@@ -169,8 +169,9 @@
     "\n",
     "fig, ax = plt.subplots()\n",
     "ax.plot(trib_chi,trib_z)\n",
-    "ax.set_xlabel('$\\chi$')\n",
-    "ax.set_ylabel('elevation, m')"
+    "ax.set_xlabel(r'$\\chi$')\n",
+    "ax.set_ylabel('elevation, m')\n",
+    "plt.show()"
    ]
   },
   {
@@ -199,14 +200,6 @@
     "    \n",
     "    ax.scatter(trib_x, trib_y, c=trib_chi, cmap='inferno_r', s=0.5, vmin=0, vmax=np.max(s_chi))   # note that we use common min/max values for all tributaries"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "14",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {},


### PR DESCRIPTION
There were two places where equations were not rendering properly.

The first was because of an extra space after the equation.

The second is because of improper escaping. Strings with LaTeX commands need to be raw strings (i.e. r'$\chi$').