### PR TITLE
georef -> crs in write_tif

### DIFF
--- a/src/topotoolbox/utils.py
+++ b/src/topotoolbox/utils.py
@@ -60,7 +60,7 @@ def write_tif(dem: GridObject, path: str) -> None:
             height=dem.rows,
             width=dem.columns,
             dtype=np.float32,
-            georef=dem.georef,
+            crs=dem.georef,
             transform=dem.transform
     ) as dataset:
         dataset.write(dem.z, 1)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,15 @@
+import tempfile
+import os
+
+import topotoolbox as tt3
+
+
+def test_write_tif_georef():
+    dem = tt3.load_dem('bigtujunga')
+    with tempfile.TemporaryDirectory() as tmp:
+        path = os.path.join(tmp, 'output.tif')
+        tt3.write_tif(dem, path)
+        dem2 = tt3.read_tif(path)
+        assert dem2.georef == dem.georef
+
+        os.remove(path)


### PR DESCRIPTION
Use the crs argument to rasterio.open instead of our georef. This was improperly changed during the mass renaming of #318, and without a test was not caught. A test is added to make sure that this continues to work.