### PR TITLE
Use hillshade_fused by default

### DIFF
--- a/src/lib/grid.cpp
+++ b/src/lib/grid.cpp
@@ -268,6 +268,20 @@ void wrap_hillshade(py::array_t<float> output,
             dims_array.data());
 }
 
+void wrap_hillshade_fused(py::array_t<float> output,
+                          py::array_t<float> dem,
+                          float azimuth, float altitude, float cellsize,
+                          std::tuple<ptrdiff_t, ptrdiff_t> dims) {
+
+  float *output_ptr = output.mutable_data();
+
+  float *dem_ptr = dem.mutable_data();
+
+  std::array<ptrdiff_t, 2> dims_array = {std::get<0>(dims), std::get<1>(dims)};
+  hillshade_fused(output_ptr, dem_ptr, azimuth, altitude,
+                  cellsize, dims_array.data());
+}
+
 // Make wrap_funcname() function available as funcname() to be used by
 // by functions in the pytopotoolbox package
 
@@ -283,4 +297,5 @@ PYBIND11_MODULE(_grid, m) {
     m.def("flow_routing_d8_edgelist", &wrap_flow_routing_d8_edgelist);
     m.def("gradient8", &wrap_gradient8);
     m.def("hillshade", &wrap_hillshade);
+    m.def("hillshade_fused", &wrap_hillshade_fused);
 }

--- a/tests/test_grid_object.py
+++ b/tests/test_grid_object.py
@@ -225,6 +225,16 @@ def test_hillshade_order(order_dems):
         assert topo.validate_alignment(fdem, hf)
 
 
+def test_hillshade_fused(wide_dem):
+    for azimuth in np.arange(0.0, 360.0, 2.3):
+        h1 = wide_dem.hillshade(azimuth=azimuth, fused=True)
+        h2 = wide_dem.hillshade(azimuth=azimuth, fused=False)
+        assert np.allclose(h1, h2)
+
+        assert topo.validate_alignment(wide_dem, h1)
+        assert topo.validate_alignment(wide_dem, h2)
+
+
 def test_hillshade_types(types_dems):
     dem32, dem64 = types_dems
 


### PR DESCRIPTION
This is the lower-memory version of hillshade available from libtopotoolbox. It can be slightly faster for large DEMs and avoids excessive memory allocation. An option is provided to hillshade to used the fused implementation or not, with the default to use the fused version.

A test is added to ensure that the fused and unfused implementations return the same values.