### PR TITLE
Add CITATION.cff file and Zenodo DOI badge

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,29 @@
+title: 'TopoToolbox/pytopotoolbox: v0.0.6'
+type: software
+version: v0.0.6
+message: If you use this software, please cite it using the metadata from this file.
+authors:
+- affiliation: University of Potsdam
+  given-names: William
+  family-names: Kearney
+- affiliation: University of Potsdam
+  given-names: Theophil
+  family-names: Bringezu
+- given-names: Gina
+  family-names: Arnau
+- affiliation: "G\xE9osciences Rennes"
+  given-names: Boris
+  family-names: Gailleton
+- affiliation: GFZ
+  given-names: Luca
+  family-names:  Malatesta
+- family-names: Faure
+  given-names: "Fran\xE7ois"
+- given-names: Xiaochuan
+  family-names: Ye
+cff-version: 1.2.0
+date-released: '2025-08-05'
+doi: 10.5281/zenodo.16742466
+license:
+- GPL-3.0-only
+repository-code: https://github.com/TopoToolbox/pytopotoolbox/tree/v0.0.6

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 [![PyPI - Version](https://img.shields.io/pypi/v/topotoolbox)](https://pypi.org/project/topotoolbox/)
 [![Tests](https://github.com/topotoolbox/pytopotoolbox/workflows/CI/badge.svg)](https://github.com/topotoolbox/pytopotoolbox/actions)
 [![GitHub License](https://img.shields.io/github/license/topotoolbox/pytopotoolbox)](https://github.com/TopoToolbox/pytopotoolbox#GPL-3.0-1-ov-file)
+[![DOI](https://zenodo.org/badge/777258209.svg)](https://doi.org/10.5281/zenodo.16742408)
 
 # pytopotoolbox
 

--- a/docs/dev.rst
+++ b/docs/dev.rst
@@ -99,7 +99,12 @@ To release a new version of pytopotoolbox:
    version number in pyproject.toml
 3. Publish the release. This will trigger our release workflow, which
    will build and upload binary wheels to the GitHub release and to
-   PyPi.
+   PyPi. It will also automatically be archived on Zenodo.
+4. Update the CITATION.cff file with the new version number and DOI
+   from Zenodo. Because the DOI will not be issued until after the
+   release is made, this change must be made AFTER the release is
+   issued. Any additional changes to the CITATION.cff file can be made
+   at this time.
 
 Pre-Commit Hooks
 ----------------


### PR DESCRIPTION
Versions v0.0.6 and later will be automatically archived on
Zenodo. The badge will link to the latest archived version on Zenodo.

The CITATION.cff file supplies metadata to Zenodo and to Github. I
automatically generated it from the Zenodo release and then lightly
modified it. Contributors should check their affiliations and add
themselves manually to the CITATION.cff file.

CITATION.cff will need to be updated AFTER a release is made and
archived on Zenodo, because you need the DOI. Documentation is added to docs/dev.rst to record this process.