### PR TITLE
Add GraphFlood example

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -4,3 +4,4 @@ Examples
 .. nbgallery::
    /examples/magicfunctions
    /examples/excesstopography
+   /examples/GraphFlood

--- a/docs/examples/GraphFlood.ipynb
+++ b/docs/examples/GraphFlood.ipynb
@@ -1,0 +1,98 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "0",
+   "metadata": {},
+   "source": [
+    "GraphFlood ([Gailleton et al., 2024](https://doi.org/10.5194/esurf-12-1295-2024)) is an efficient algorithm for realistic flow modeling on large DEMs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import topotoolbox as tt3\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "from matplotlib.colors import ListedColormap, LogNorm\n",
+    "from matplotlib.ticker import FuncFormatter\n",
+    "from mpl_toolkits.axes_grid1 import make_axes_locatable"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2",
+   "metadata": {},
+   "source": [
+    "We will replicate the example from the Green River, Utah, USA (Gailleton et al., 2024, Fig. 4). First, we need to obtain the DEM. We can download a 1 m lidar-derived DEM courtesy of Cole Speed and the National Center for Airborne Laser Mapping of the area from [OpenTopography](https://doi.org/10.5069/G9J964J3). Unfortunately, TopoToolbox's `load_opentopography` can only download global DEMs from OpenTopography, so we instead provide a portion of this DEM through the `load_dem` function.\n",
+    "\n",
+    "We will load the DEM and then run GraphFlood using the `run_graphflood` function. This takes a `GridObject` representing the DEM and a bunch of other parameters. We'll use the default values for all of these except the precipitation, `p`, which we will set to 100 mm/h."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dem = tt3.load_dem('greenriver')\n",
+    "h = tt3.run_graphflood(dem, p = 100/1000/3600)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4",
+   "metadata": {},
+   "source": [
+    "The output of `run_graphflood` is a `GridObject` containing the water depth at each point. We visualize the water depth over a hillshade of the DEM."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig,ax = plt.subplots(1,1, layout=\"constrained\")\n",
+    "\n",
+    "dem.plot_hs(ax=ax, cmap=ListedColormap([0.7, 0.7, 0.7]), exaggerate=3, interpolation_stage=\"rgba\")\n",
+    "cmap = plt.cm.Blues\n",
+    "norm = LogNorm(0.001, 1.0)\n",
+    "hplot = h.plot(ax=ax, alpha=1.0, cmap=cmap, norm=norm)\n",
+    "\n",
+    "cb = fig.colorbar(hplot, ax=ax)\n",
+    "cb.set_label(label='h [m]')\n",
+    "\n",
+    "km_formatter = FuncFormatter(lambda x, pos: f'{x/1000:.1f}')\n",
+    "ax.xaxis.set_major_formatter(km_formatter)\n",
+    "ax.yaxis.set_major_formatter(km_formatter)\n",
+    "\n",
+    "ax.set_xlim(562200, 562700)\n",
+    "ax.set_ylim(4304000, 4304800)\n",
+    "ax.set_xlabel(\"East [km]\")\n",
+    "ax.set_ylabel(\"North [km]\");\n",
+    "#fig.savefig(\"graphflood.png\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6",
+   "metadata": {},
+   "source": [
+    "# References\n",
+    "\n",
+    "- Speed, C. (2020). Interpreting Fluvial Processes from Channel-Belt Deposits, Utah 2018. National Center for Airborne Laser Mapping (NCALM). Distributed by OpenTopography. https://doi.org/10.5069/G9J964J3. Accessed 2025-08-14\n",
+    "- Gailleton, B. et al. (2024) GraphFlood 1.0: an efficient algorithm to approximate 2D hydrodynamics for landscape evolution models. Earth Surface Dynamics, 12, 1295--1313, https://doi.org/10.5194/esurf-12-1295-2024"
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
This adds a Jupyter notebook that runs GraphFlood on the Green River DEM as in Gailleton et al. (2024). This generates the figure that is planned for the TT3 manuscript.

@bgailleton: Any ideas for improving this example?