### PR TITLE
Fix release CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,7 @@ jobs:
         with:
           name: cibw-sdist
           path: dist/*.tar.gz
+
   build_wheels:
     if: github.repository == 'TopoToolbox/pytopotoolbox'
     name: Wheel on ${{ matrix.os }}
@@ -49,11 +50,19 @@ jobs:
           CIBW_TEST_REQUIRES: pytest
           CIBW_TEST_COMMAND: pytest {package}/tests
           CIBW_TEST_EXTRAS: opensimplex
+          # --- Option A: force binary deps during Linux test installs ---
+          # Keep pip new (helps resolver pick wheels)
+          CIBW_BEFORE_TEST_LINUX: python -m pip install -U pip
+          # Ensure pip never builds deps like pyproj from sdist inside manylinux
+          CIBW_ENVIRONMENT_LINUX: >
+            PIP_ONLY_BINARY=":all:"
+            PIP_NO_BUILD_ISOLATION="false"
 
       - uses: actions/upload-artifact@v4
         with:
           name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}
           path: ./wheelhouse/*.whl
+
   upload_assets:
     if: github.repository == 'TopoToolbox/pytopotoolbox'
     name: Upload release assets
@@ -72,6 +81,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ github.event.release.tag_name }}
+
   upload-pypi:
     if: github.repository == 'TopoToolbox/pytopotoolbox'
     name: Upload release assets to PyPI


### PR DESCRIPTION
This PR tries to fix the CI for linux.

It may require a couple of PRs to achieve it.

Problem: some distributions somhow fallsback to `sdist` compilation of pyproj instead of using the binary wheel from pypi. I modified the workflow to make sure it forces binaries.

Next steps if fails: as it is platform specific and only happens during the specific test for geopandas+ttb (not the actual unit test of `pytopotoolbox` if I understand correctly), we could skip the geopandas tests if fails. 