### PR TITLE
fix release v2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,13 +50,11 @@ jobs:
           CIBW_TEST_REQUIRES: pytest
           CIBW_TEST_COMMAND: pytest {package}/tests
           CIBW_TEST_EXTRAS: opensimplex
-          # --- Option A: force binary deps during Linux test installs ---
-          # Keep pip new (helps resolver pick wheels)
-          CIBW_BEFORE_TEST_LINUX: python -m pip install -U pip
-          # Ensure pip never builds deps like pyproj from sdist inside manylinux
-          CIBW_ENVIRONMENT_LINUX: >
-            PIP_ONLY_BINARY=":all:"
-            PIP_NO_BUILD_ISOLATION="false"
+          # Assure wheels pour les installs de test (Linux seulement)
+          CIBW_TEST_ENVIRONMENT_LINUX: PIP_ONLY_BINARY=":all:"
+          # Optionnel: pip récent avant build
+          CIBW_BEFORE_BUILD: python -m pip install -U pip
+
 
       - uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
Second try for fixing the CI release system (pyproj is buggy).

Restrict the build system to binary only just for the tests