### PR TITLE
Add test for graphflood object

### DIFF
--- a/src/topotoolbox/graphflood_object.py
+++ b/src/topotoolbox/graphflood_object.py
@@ -72,7 +72,7 @@ class GFObject():
                 raise RuntimeError(
                     "Precipitation array must match grid dimensions"
                 )
-            self._precipitations = p.ravel(order="C")
+            self._precipitations = p
         elif isinstance(p, GridObject):
             if p.shape != grid.shape:
                 raise RuntimeError(


### PR DESCRIPTION
Add unit test for GraphFlood Object alongside a minor fix for ingesting 2D precipitations as numpy array directly.