### PR TITLE
Reinstall pandas and geopandas when downgrading numpy

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,7 +37,7 @@ jobs:
       - name: Downgrade numpy
         if: ${{ matrix.python-version <= '3.11' }}
         run: |
-          pip install matplotlib scipy rasterio "numpy==1.23.5" --upgrade --upgrade-strategy eager
+          pip install matplotlib scipy rasterio pandas geopandas "numpy==1.23.5" --upgrade --upgrade-strategy eager
           pytest
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This fixes recent CI errors. pandas must have dropped support for numpy 1.23.5.