### PR TITLE
Remove binding to libtopotoolbox's flow_accumulation

### DIFF
--- a/src/lib/flow.cpp
+++ b/src/lib/flow.cpp
@@ -12,47 +12,6 @@ extern "C" {
 
 namespace py = pybind11;
 
-// wrap_flow_accumulation:
-// Parameters:
-//   acc: A 2D NumPy array (float) representing the accumulation matrix. 
-//        This matrix will be modified in-place to store the accumulated flow
-//        values based on the given flow directions and weights.
-//
-//   source: A 2D NumPy array (ptrdiff_t) representing the source cell indices.
-//           This array contains the cell indices (or indices) from which the 
-//           flow originates or accumulates.
-//
-//   direction: A 2D NumPy array (uint8_t) representing the flow direction for 
-//              each cell in the grid. This array contains encoded flow 
-//              direction values (e.g., D8 flow directions) to specify how 
-//              flow moves between cells in the grid.
-//
-//   weights: A 2D NumPy array (float) representing the weights or flow values
-//            assigned to each cell. These values are used to weight the
-//            accumulation of flow from one cell to its neighbors.
-//
-//   dims: A tuple values representing the dimensions of the grid (number of 
-//         rows and  columns) where flow accumulation is performed.
-
-void wrap_flow_accumulation(
-        py::array_t<float> acc,
-        py::array_t<ptrdiff_t> source,
-        py::array_t<ptrdiff_t> target,
-        py::array_t<float> fraction,
-        py::array_t<float> weights,
-        std::tuple<ptrdiff_t,ptrdiff_t> dims){
-
-    float *acc_ptr = acc.mutable_data();
-    ptrdiff_t *source_ptr = source.mutable_data();
-    ptrdiff_t *target_ptr = target.mutable_data();
-    float *fraction_ptr = fraction.mutable_data();
-    float *weights_ptr = weights.mutable_data();
-    
-    std::array<ptrdiff_t, 2> dims_array = {std::get<0>(dims), std::get<1>(dims)};
-    ptrdiff_t *dims_ptr = dims_array.data();
-    flow_accumulation_edgelist(acc_ptr, source_ptr, target_ptr, fraction_ptr, weights_ptr, source.size(), dims_ptr);
-}
-
 void wrap_drainagebasins(py::array_t<ptrdiff_t> basins,
                          py::array_t<ptrdiff_t> source,
                          py::array_t<ptrdiff_t> target,
@@ -70,6 +29,5 @@ void wrap_drainagebasins(py::array_t<ptrdiff_t> basins,
 // by functions in the pytopotoolbox package
 
 PYBIND11_MODULE(_flow, m) {
-  m.def("flow_accumulation", &wrap_flow_accumulation);
   m.def("drainagebasins", &wrap_drainagebasins);
 }

--- a/src/topotoolbox/flow_object.py
+++ b/src/topotoolbox/flow_object.py
@@ -252,14 +252,11 @@ class FlowObject():
         >>> acc = fd.flow_accumulation()
         >>> acc.plot(cmap='Blues',norm="log")
         """
-        acc = np.zeros(self.shape, dtype=np.float32, order=self.order)
-
-        w = self.ezgetnal(weights, dtype=np.float32)
+        acc = np.array(self.ezgetnal(weights, dtype=np.float32), copy=True, order=self.order)
 
         fraction = np.ones_like(self.source, dtype=np.float32)
 
-        _flow.flow_accumulation(
-            acc, self.source, self.target, fraction, w, self.shape)
+        _stream.traverse_down_f32_add_mul(acc, fraction, self.source, self.target)
 
         result = GridObject()
         result.path = self.path


### PR DESCRIPTION
Replaces it with `traverse_down_f32_add_mul`. See deprecation notice in TopoToolbox/libtopotoolbox#211.

I noticed some counterintuitive behavior around memory ordering in the StreamObject constructor that prevents us from just using the `FlowObject.flow_accumulation`, which would be ideal. However, fixing that requires some more complicated changes to StreamObject and possibly changes to the tests, so I made a note.