### PR TITLE
Add FlowObject.getoutlets

### DIFF
--- a/src/topotoolbox/flow_object.py
+++ b/src/topotoolbox/flow_object.py
@@ -271,6 +271,34 @@ class FlowObject():
 
         return result
 
+    def getoutlets(self):
+        """Extract outlets from a flow network.
+
+        These are defined as nodes that have no downstream neighbor in
+        the network. This includes any internal sinks as well as
+        outlets where flow exits the DEM.
+
+        Returns
+        -------
+        GridObject
+            A logical GridObject that is True for each node that is
+            considered an outlet. False otherwise.
+
+        Example
+        -------
+        >>> dem = topotoolbox.load_dem("bigtujunga")
+        >>> fd = topotoolbox.FlowObject(dem)
+        >>> outlets = fd.getoutlets()
+        >>> outlets.plot()
+
+        """
+        indegree = np.zeros(self.shape, order=self.order, dtype=np.uint8)
+        outdegree = np.zeros(self.shape, order=self.order, dtype=np.uint8)
+        _stream.edgelist_degree(indegree, outdegree, self.source, self.target)
+        output = (outdegree == 0) & (indegree > 0)
+
+        return np.nonzero(np.ravel(output, order='K'))[0]
+
     def drainagebasins(self, outlets=None):
         """Delineate drainage basins from a flow network.
 

--- a/tests/test_flow_object.py
+++ b/tests/test_flow_object.py
@@ -330,3 +330,38 @@ def test_influence_map(order_dems):
     fd = ffd.influencemap(l_f)
 
     assert np.array_equal(cd, fd)
+
+def test_getoutlets(wide_dem):
+    # The outlets determined by FlowObject.getoutlets should be a
+    # superset of those determined by s.streampoi('outlets')
+
+    fd = topo.FlowObject(wide_dem)
+    s = topo.StreamObject(fd, threshold=1)
+
+    soutlets = s.streampoi('outlets')
+    sog = np.zeros(fd.shape, dtype=bool)
+    sog[s.node_indices_where(soutlets)] = True
+
+    foutlets = fd.getoutlets()
+    fog = np.zeros(fd.shape, dtype=bool)
+    fog[fd.unravel_index(foutlets)] = True
+
+    assert np.all(fog[sog])
+
+def test_getoutlets_order(order_dems):
+    # Identified outlets should be invariant of the memory ordering.
+    cdem, fdem = order_dems
+
+    cfd = topo.FlowObject(cdem)
+    ffd = topo.FlowObject(fdem)
+
+    coutlets = cfd.getoutlets()
+    cog = np.zeros(cfd.shape, dtype=bool)
+    cog[cfd.unravel_index(coutlets)] = True
+
+    foutlets = ffd.getoutlets()
+    fog = np.zeros(ffd.shape, dtype=bool)
+    fog[ffd.unravel_index(foutlets)] = True
+
+    assert np.count_nonzero(cog) > 0
+    assert np.array_equal(cog, fog)


### PR DESCRIPTION
This corresponds to MATLAB's FLOWobj.getoutlets. It returns a list of linear indices of the outlets in the flow network. Use FlowObject.unravel_index to convert these indices to multidimensional indices for indexing into a GridObject-shaped array.

Tests to ensure that this function corresponds to
StreamObject.streampoi and that returned indices have the correct memory order are added.

This will be useful for #369.