### PR TITLE
Fix memory ordering issues in StreamObject constructor

### DIFF
--- a/src/topotoolbox/stream_object.py
+++ b/src/topotoolbox/stream_object.py
@@ -145,6 +145,7 @@ class StreamObject():
                     avg = (flow.shape[0] + flow.shape[1])//2
                     threshold = np.full(
                         self.shape, math.floor((avg ** 2) * 0.01),
+                        order = self._order,
                         dtype=np.float32)
                 else:
                     threshold = np.full(


### PR DESCRIPTION
Resolves #368

This was not as complicated as expected in #368: The issue was that the `threshold` array was being created in row-major order. Previously `acc >= threshold` was returned in column-major order because `acc` was explicitly created in column-major, and I guess numpy decides the order of its argument based on the first one. But then when acc was derived from `flow_accumulation` on a row-major ordered FlowObject, the result of `acc >= threshold` was row-major and then raveling as column-major confused things.

This change creates every array with the source memory ordering and uses `ravel(order='K')` where
necessary. `FlowObject.flow_accumulation` can now be used to compute the flow accumulation raster without calling
`_stream.traverse_down_f32_add_mul`.

<strike>The tests pass.</strike> That's embarrassing.