### PR TITLE
Remove final uses of order='F'

### DIFF
--- a/src/topotoolbox/grid_object.py
+++ b/src/topotoolbox/grid_object.py
@@ -45,7 +45,7 @@ class GridObject():
         self.name = ''
 
         # raster metadata
-        self.z: npt.NDArray = np.empty((), order='F', dtype=np.float32)
+        self.z: npt.NDArray = np.empty((), dtype=np.float32)
 
         self.cellsize = 0.0  # in meters if crs.is_projected == True
 
@@ -1081,91 +1081,6 @@ class GridObject():
         result = cp.copy(self)
         result.z = h
         return result
-
-    def _gwdt_computecosts(self) -> np.ndarray:
-        """
-        Compute the cost array used in the gradient-weighted distance
-        transform (GWDT) algorithm.
-
-
-        Returns
-        -------
-        np.ndarray
-            A 2D array of costs corresponding to each grid cell in the DEM.
-        """
-        dem = self.z
-        flats = self.identifyflats(raw=True)[0]
-        filled_dem = self.fillsinks().z
-        dims = self.shape
-        costs = np.zeros_like(dem, dtype=np.float32, order='F')
-        conncomps = np.zeros_like(dem, dtype=np.int64, order='F')
-
-        _grid.gwdt_computecosts(costs, conncomps, flats, dem, filled_dem, dims)
-        del conncomps, flats, filled_dem
-        return costs
-
-    def _gwdt(self) -> np.ndarray:
-        """
-        Perform the grey-weighted distance transform (GWDT) on the DEM.
-
-        Returns
-        -------
-        np.ndarray
-            A 2D array representing the GWDT distances for each grid cell.
-        """
-        costs = self._gwdt_computecosts()
-        flats = self.identifyflats(raw=True)[0]
-        dims = self.shape
-        dist = np.zeros_like(flats, dtype=np.float32, order='F')
-        prev = np.zeros_like(flats, dtype=np.int64, order='F')
-        heap = np.zeros_like(flats, dtype=np.int64, order='F')
-        back = np.zeros_like(flats, dtype=np.int64, order='F')
-
-        _grid.gwdt(dist, prev, costs, flats, heap, back, dims)
-        del costs, prev, heap, back
-        return dist
-
-    def _flow_routing_d8_carve(self) -> tuple[np.ndarray, np.ndarray]:
-        """
-        Compute the flow routing using the D8 algorithm with carving
-        for flat areas.
-
-        Returns
-        -------
-        np.ndarray
-            array indicating the source cells for flow routing. (source)
-        np.ndarray
-            array indicating the flow direction for each grid cell. (direction)
-        """
-        filled_dem = self.fillsinks().z
-        dist = self._gwdt()
-        flats = self.identifyflats(raw=True)[0]
-        dims = self.shape
-        source = np.zeros_like(flats, dtype=np.int64, order='F')
-        direction = np.zeros_like(flats, dtype=np.uint8, order='F')
-
-        _grid.flow_routing_d8_carve(
-            source, direction, filled_dem, dist, flats, dims)
-        del filled_dem, dist, flats
-        return source, direction
-
-    def _flow_routing_targets(self) -> np.ndarray:
-        """
-        Identify the target cells for flow routing.
-
-        Returns
-        -------
-        np.ndarray
-            A 2D array where each cell points to its downstream target cell.
-        """
-
-        source, direction = self._flow_routing_d8_carve()
-        dims = self.shape
-        target = np.zeros_like(source, dtype=np.int64, order='F')
-
-        _grid.flow_routing_targets(target, source, direction, dims)
-        del source, direction
-        return target
 
     def info(self) -> None:
         """Prints all variables of a GridObject.

--- a/src/topotoolbox/utils.py
+++ b/src/topotoolbox/utils.py
@@ -158,7 +158,7 @@ def read_tif(path: str) -> GridObject:
         grid.path = path
         grid.name = os.path.splitext(os.path.basename(grid.path))[0]
 
-        grid.z = dataset.read(1).astype(np.float32, order='F')
+        grid.z = dataset.read(1).astype(np.float32)
 
         grid.cellsize = dataset.res[0]
         grid.bounds = dataset.bounds
@@ -211,7 +211,7 @@ def gen_random(hillsize: int = 24, rows: int = 128, columns: int = 128,
                "box[opensimplex]\" or \"pip install .[opensimplex]\"")
         raise ImportError(err) from None
 
-    noise_array = np.empty((rows, columns), dtype=np.float32, order='F')
+    noise_array = np.empty((rows, columns), dtype=np.float32)
 
     simplex.seed(seed)
     for y in range(0, rows):


### PR DESCRIPTION
Resolves #201

This makes four changes to finish removing instances where we need to create an array with column-major ordering.

- In the `GridObject.__init__` method, we create a 0-dimensional empty array. The memory ordering doesn't matter because it is empty.

- The wrapper methods for various libtopotoolbox functions are removed entirely. Technically they could be corrected to remove the column-major creation, but they are unused and clutter things up.

- `read_tif` now reads a band of data in the native memory order, which is probably 'C' (I'm not sure if rasterio will ever return an 'F' order array).

- `gen_random` now creates a noise array in the 'C' order.