### PR TITLE
Rename streamorder memory ordering test

### DIFF
--- a/tests/test_stream_object.py
+++ b/tests/test_stream_object.py
@@ -603,7 +603,7 @@ def test_ksn(wide_dem):
     k = s.ksn(wide_dem, A, theta)
 
 
-def test_streamorder(cfd, ffd, cs, fs):
+def test_streamorder_order(cfd, ffd, cs, fs):
     cds = cs.streamorder()
     fds = fs.streamorder()
 


### PR DESCRIPTION
This is for consistency with other memory ordering tests, which is useful for monitoring coverage of these tests.