### PR TITLE
Parameterize excesstopography memory order test by threshold_slopes

### DIFF
--- a/src/topotoolbox/grid_object.py
+++ b/src/topotoolbox/grid_object.py
@@ -434,9 +434,13 @@ class GridObject():
         if isinstance(threshold, (float, int)):
             threshold_slopes = np.full_like(dem, threshold)
         elif isinstance(threshold, GridObject):
-            threshold_slopes = np.asarray(threshold, dtype=np.float32)
+            threshold_slopes = np.asarray(threshold,
+                                          order='F' if self.z.flags.f_contiguous else 'C',
+                                          dtype=np.float32)
         elif isinstance(threshold, np.ndarray):
-            threshold_slopes = np.asarray(threshold, dtype=np.float32)
+            threshold_slopes = np.asarray(threshold,
+                                          order='F' if self.z.flags.f_contiguous else 'C',
+                                          dtype=np.float32)
         else:
             err = "Threshold must be a float, int, GridObject, or np.ndarray."
             raise TypeError(err) from None


### PR DESCRIPTION
This randomly generates a threshold slopes in the Numpy default row-major ordering as either an ndarray or as a GridObject. This is then passed to the excesstopography order test. The `method` argument is converted to a pytest parameter rather than using a for loop.

This test initially fails because the threshold array is passed directly to libtopotoolbox. Now the array is copied to the correct memory order if necessary.