### PR TITLE
Run fillsinks order test with bc and hybrid arguments

### DIFF
--- a/src/topotoolbox/grid_object.py
+++ b/src/topotoolbox/grid_object.py
@@ -304,8 +304,8 @@ class GridObject():
                    f"match the shape of the DEM. {self.shape}")
             raise ValueError(err)from None
 
-        if isinstance(bc, GridObject):
-            bc = bc.z
+        bc = np.asarray(bc, dtype=np.uint8,
+                        order = 'F' if dem.flags.f_contiguous else 'C')
 
         if hybrid:
             queue = np.zeros_like(dem, dtype=np.int64)

--- a/tests/test_grid_object.py
+++ b/tests/test_grid_object.py
@@ -116,14 +116,23 @@ def test_fillsinks(square_dem, wide_dem, tall_dem):
 
                 assert sink < 8
 
-
-def test_fillsinks_order(order_dems):
+@pytest.mark.parametrize("hybrid",[True, False])
+@pytest.mark.parametrize("bc",[True, False])
+def test_fillsinks_order(order_dems, hybrid, bc):
     cdem, fdem = order_dems
 
-    cfilled = cdem.fillsinks()
+    if bc:
+        bc = np.ones_like(cdem.z, dtype=np.uint8)
+        bc[1:-1, 1:-1] = 0
+
+        bc = cdem.duplicate_with_new_data(bc)
+    else:
+        bc = None
+
+    cfilled = cdem.fillsinks(bc=bc, hybrid=hybrid)
     assert cfilled.z.flags.c_contiguous
 
-    ffilled = fdem.fillsinks()
+    ffilled = fdem.fillsinks(bc=bc, hybrid=hybrid)
     assert ffilled.z.flags.f_contiguous
 
     assert np.array_equal(ffilled, cfilled)


### PR DESCRIPTION
This PR adds a few test parameters that test both fillsinks methods and to provide the boundary condition explicitly as a GridObject.

When the bc is provided explicitly, it is not converted to the right data type and order, so this is corrected by using `np.asarray` to convert it if necessary.