### PR TITLE
Replace GridObject.resample with a call to GridObject.reproject

### DIFF
--- a/src/topotoolbox/grid_object.py
+++ b/src/topotoolbox/grid_object.py
@@ -229,32 +229,7 @@ class GridObject():
         >>> im = dem_90m.plot(cmap="terrain")
         >>> plt.show()
         """
-        dst = GridObject()
-
-        z, dst.transform = reproject(
-            self.z,
-            src_transform=self.transform,
-            src_crs=self.georef,
-            dst_transform=None,  # Let rasterio derive the transform for us
-            dst_crs=self.georef,  # Same CRS as source
-            dst_nodata=np.nan,
-            dst_resolution=resolution,
-            resampling=resampling,
-        )
-        # reproject gives us a 3D array, we want the first band.
-        dst.z = np.zeros_like(self.z, shape=z.shape[1:3])
-        dst.z[:, :] = z[0, :, :]
-
-        dst.georef = self.georef  # Keep the same CRS
-
-        # Get cellsize from transform
-        if dst.transform is not None:
-            dst.cellsize = abs(dst.transform[0])
-
-        if self.bounds:
-            dst.bounds = self.bounds  # Same bounds, just different resolution
-
-        return dst
+        return self.reproject(self.georef, resolution, resampling)
 
     def fillsinks(self,
                   bc: 'np.ndarray | GridObject | None' = None,

--- a/tests/test_grid_object.py
+++ b/tests/test_grid_object.py
@@ -386,6 +386,14 @@ def test_reproject_order(order_dems):
 
     assert np.allclose(f2, c2, equal_nan=True)
 
+def test_resample_order(order_dems):
+    cdem, fdem = order_dems
+
+    c2 = cdem.resample(15.0)
+    f2 = fdem.resample(15.0)
+
+    assert np.allclose(f2, c2)
+
 def test_zscore_order(order_dems):
     cdem, fdem = order_dems
 


### PR DESCRIPTION
GridObject.resample is essentially identical to GridObject.reproject but uses the source CRS as the destination CRS. We should be able to call reproject, passing in the self.georef parameter, if we are just interested in resampling.

@bgailleton: You added this in #354. It's good to have `resample` to match the MATLAB interface at least, but is there a reason I am not seeing why we can't call `GridObject.reproject` with the correct CRS when resampling?