### PR TITLE
Parameterize StreamObject.chitransform memory order test

### DIFF
--- a/tests/test_stream_object.py
+++ b/tests/test_stream_object.py
@@ -214,12 +214,14 @@ def test_run_chitransform(tall_flow, wide_flow, tall_stream, wide_stream):
     wide_stream.chitransform(wide_acc)
 
 
-def test_chitransform_order(cfd, ffd, cs, fs):
-    ca = cfd.flow_accumulation()
-    fa = ffd.flow_accumulation()
+@pytest.mark.parametrize("acctype", [np.float32, np.float64])
+@pytest.mark.parametrize("k", [None, 1e-5])
+def test_chitransform_order(cfd, ffd, cs, fs, k, acctype):
+    ca = np.asarray(cfd.flow_accumulation(), dtype=acctype)
+    fa = np.asarray(ffd.flow_accumulation(), dtype=acctype)
 
-    cchi = cs.chitransform(ca)
-    fchi = fs.chitransform(fa)
+    cchi = cs.chitransform(ca, k = k)
+    fchi = fs.chitransform(fa, k = k)
 
     cchimap = np.zeros(cs.shape)
     fchimap = np.zeros(fs.shape)


### PR DESCRIPTION
This adds a k parameter, which passes the erosional efficiency to chitransform, and an acctype, which changes the type of the input flow accumulation, which integrates the area using streamquad_trapz_f64 rather than streamquad_trapz_f32.