### PR TITLE
Build wheels on macos-15-intel and CPython 3.14

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,9 +31,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest, macos-13]
+        os: [ubuntu-latest, macos-latest, windows-latest, macos-15-intel]
         cibw_arch: ["native"]
-        cibw_build: ["cp310-* cp311-* cp312-* cp313-*"]
+        cibw_build: ["cp311-* cp312-* cp313-* cp314-*"]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0


### PR DESCRIPTION
Drops wheel builds on macos-13 and CPython 3.10. We are out of the Scientific Python support window for CPython 3.10 (and actually 3.11), and GitHub no longer provides the macos-13 runners.