### PR TITLE
Bump version number to 0.0.10 for release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,10 +9,10 @@ requires = [
 
 [project]
 name = "topotoolbox"
-version = "0.0.8"
+version = "0.0.10"
 authors = [
     {name="Wolfgang Schwanghart", email="w.schwanghart@geo.uni-potsdam.de"},
-    {name="Dirk Scherler", email="scherler@fz-potsdam.de"},
+    {name="Dirk Scherler", email="scherler@gfz-potsdam.de"},
     {name="Will Kearney", email="william.kearney@uni-potsdam.de"},
     {name="Theo Bringezu", email="theophil.bringezu@uni-potsdam.de"}
 ]


### PR DESCRIPTION
v0.0.8 failed to build the wheels and release to PyPI. v0.0.9 did not have the right version in pyproject.toml