### PR TITLE
Wrap and test new libtopotoolbox edgeset functions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ include(FetchContent)
 FetchContent_Declare(
   topotoolbox
   GIT_REPOSITORY https://github.com/TopoToolbox/libtopotoolbox.git
-  GIT_TAG 2f7f08b7f7768736ad0235545b9f8a401259395c
+  GIT_TAG be68210064ac0ebe9c3328873099401540b63aa3
 )
 FetchContent_MakeAvailable(topotoolbox)
 
@@ -21,6 +21,8 @@ find_package(pybind11 CONFIG REQUIRED)
 pybind11_add_module(_grid src/lib/grid.cpp)
 target_link_libraries(_grid PRIVATE topotoolbox)
 
+pybind11_add_module(_flow src/lib/flow.cpp)
+target_link_libraries(_flow PRIVATE topotoolbox)
 
 pybind11_add_module(_stream src/lib/stream.cpp)
 target_link_libraries(_stream PRIVATE topotoolbox)
@@ -34,4 +36,4 @@ target_link_libraries(_morphology PRIVATE topotoolbox)
 pybind11_add_module(_swaths src/lib/swaths.cpp)
 target_link_libraries(_swaths PRIVATE topotoolbox)
 
-install(TARGETS _grid _stream _graphflood _morphology _swaths LIBRARY DESTINATION topotoolbox)
+install(TARGETS _grid _flow _stream _graphflood _morphology _swaths LIBRARY DESTINATION topotoolbox)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,6 @@ disable = [
     "too-many-locals",
     "duplicate-code",
     "cyclic-import",
-    "too-many-positional-arguments",
     "too-many-lines",
     "too-many-public-methods",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ disable = [
     "too-many-branches",
     "too-many-statements",
     "too-many-locals",
+    "too-many-positional-arguments",
     "duplicate-code",
     "cyclic-import",
     "too-many-lines",

--- a/src/lib/flow.cpp
+++ b/src/lib/flow.cpp
@@ -1,0 +1,47 @@
+extern "C" {
+  #include <topotoolbox.h>
+}
+
+#include <pybind11/pybind11.h>
+#include <pybind11/numpy.h>
+
+namespace py = pybind11;
+
+ptrdiff_t wrap_edgeset_count(py::array_t<uint8_t> bitmap) {
+  ptrdiff_t dims[2] = {bitmap.shape(0), bitmap.shape(1)};
+  return edgeset_count(bitmap.mutable_data(), dims);
+}
+
+ptrdiff_t wrap_edgeset_scan(py::array_t<ptrdiff_t> scan,
+                            py::array_t<uint8_t> bitmap) {
+  ptrdiff_t dims[2] = {bitmap.shape(0), bitmap.shape(1)};
+  return edgeset_scan(scan.mutable_data(), bitmap.mutable_data(), dims);
+}
+
+ptrdiff_t wrap_edgeset_count_merged(py::array_t<uint8_t> bitmap1,
+                                    py::array_t<uint8_t> bitmap2) {
+  ptrdiff_t dims[2] = {bitmap1.shape(0), bitmap1.shape(1)};
+  return edgeset_count_merged(bitmap1.mutable_data(), bitmap2.mutable_data(),
+                              dims);
+}
+
+ptrdiff_t wrap_edgeset_merge(py::array_t<float> outweights,
+                             py::array_t<ptrdiff_t> outscan,
+                             py::array_t<uint8_t> bitmap1,
+                             py::array_t<float> weights1,
+                             py::array_t<uint8_t> bitmap2,
+                             py::array_t<float> weights2) {
+  ptrdiff_t dims[2] = {bitmap1.shape(0), bitmap1.shape(1)};
+  return edgeset_merge(outweights.mutable_data(), outscan.mutable_data(),
+                       bitmap1.mutable_data(), weights1.mutable_data(),
+                       bitmap2.mutable_data(), weights2.mutable_data(),
+                       dims);
+}
+
+
+PYBIND11_MODULE(_flow, m) {
+  m.def("edgeset_count", &wrap_edgeset_count);
+  m.def("edgeset_scan", &wrap_edgeset_scan);
+  m.def("edgeset_count_merged", &wrap_edgeset_count_merged);
+  m.def("edgeset_merge", &wrap_edgeset_merge);
+}

--- a/src/topotoolbox/flow_object.py
+++ b/src/topotoolbox/flow_object.py
@@ -7,6 +7,9 @@ import numpy as np
 # pylint: disable=no-name-in-module
 from . import _grid  # type: ignore
 from . import _stream  # type: ignore
+
+# pylint: disable=unused-import
+from . import _flow # type: ignore
 from .grid_object import GridObject
 from .interface import validate_alignment
 

--- a/src/topotoolbox/swath.py
+++ b/src/topotoolbox/swath.py
@@ -534,7 +534,8 @@ def compute_swath_distance_map(
     if half_width is not None:
         outside = best_abs > hw_px
     else:
-        outside = best_abs >= np.finfo(np.float32).max
+        outside = best_abs >= np.finfo(np.float32).max # pylint: disable=no-member
+
 
     # Convert pixel-unit distances to metres and mask outside pixels as NaN.
     dist_src = signed_dist_px if (compute_signed and signed_dist_px is not None) else best_abs
@@ -571,6 +572,7 @@ def compute_swath_distance_map(
 
     # 4. Inward distance from the boundary = min of both wave-front distances.
     mn = np.minimum(dist_pos, dist_neg)
+    # pylint: disable=no-member
     dfb_z = np.where(mn >= np.finfo(np.float32).max, np.nan, mn * grid.cellsize).astype(np.float32)
 
     cli_arr = np.empty(grid.z.size, dtype=np.float32)
@@ -613,7 +615,7 @@ def transverse_swath(grid: GridObject, distance_map: Union[GridObject, np.ndarra
     Parameters
     ----------
     grid : GridObject
-        Elevation DEM.  
+        Elevation DEM.
     distance_map : GridObject or np.ndarray
         Signed distance map in **metres** from ``compute_swath_distance_map``
         (``compute_signed=True``).  Positive values are to the left of the

--- a/tests/test_edgeset.py
+++ b/tests/test_edgeset.py
@@ -1,0 +1,58 @@
+import pytest
+
+import numpy as np
+
+import topotoolbox as tt3
+
+rng = np.random.default_rng(210057042403268582692858923958297081890)
+
+@pytest.fixture
+def bitmap1():
+    return rng.integers(0, 255, size=(11, 13), dtype=np.uint8)
+
+@pytest.fixture
+def bitmap2():
+    return rng.integers(0, 255, size=(11, 13), dtype=np.uint8)
+
+def uniform_weights(bitmap):
+    np.seterr(divide='ignore')
+    c = np.bitwise_count(bitmap)
+    w = 1 / c.flatten()
+    return np.repeat(w, c.flatten())
+
+# Numpy has a popcnt primitive that should be identical to
+# edgeset_count
+def test_edgeset_count(bitmap1):
+    c1 = tt3._flow.edgeset_count(bitmap1)
+    c2 = np.sum(np.bitwise_count(bitmap1))
+    assert c1 == c2
+
+# The bitmap scan should be identical to the cumsum of the popcnt
+# array
+def test_edgeset_scan(bitmap1):
+    scan1 = np.zeros(bitmap1.shape, dtype=np.int64)
+    c1 = tt3._flow.edgeset_scan(scan1, bitmap1)
+
+    assert c1 == tt3._flow.edgeset_count(bitmap1)
+    assert np.array_equal(np.cumsum(np.bitwise_count(bitmap1))[0:-1], scan1.flatten()[1:])
+
+def test_edgeset_count_merged(bitmap1, bitmap2):
+    c1 = tt3._flow.edgeset_count_merged(bitmap1, bitmap2)
+
+    assert c1 == np.sum(np.bitwise_count(np.bitwise_or(bitmap1, bitmap2)))
+
+def test_edgeset_merge(bitmap1, bitmap2):
+
+    weights1 = uniform_weights(bitmap1)
+    weights2 = uniform_weights(bitmap2)
+
+    scan = np.zeros(bitmap1.shape, dtype=np.int64)
+
+    c = tt3._flow.edgeset_count_merged(bitmap1, bitmap2)
+    weights = np.zeros(c, dtype=float)
+
+    c1 = tt3._flow.edgeset_merge(weights, scan, bitmap1, weights1, bitmap2, weights2)
+
+    assert c == c1
+    assert np.array_equal(scan.flatten()[1:], np.cumsum(np.bitwise_count(bitmap1))[0:-1])
+    assert np.array_equal(np.bitwise_or(bitmap1, bitmap2), bitmap1)


### PR DESCRIPTION
See #421 

This PR bumps the tag of libtopotoolbox to one including the new flow routing interface. It then adds the _flow bindings. This was removed previously because it contained only unused functions, but it is a better place for the new, more complex, flow routing routines.

Bindings are then added for the libtopotoolbox edgeset functions. These functions implement an implicit data structure containing a set of weighted edges using a bitmap and an array of weights. As is clear from the tests, these operations can easily be done with numpy functions, but the libtopotoolbox implementations are provided for consistency.

The tests run the various edgeset functions on randomly generated edgesets and compare them to the equivalent numpy implementation. It is not strictly necessary to test these functions because they are tested in libtopotoolbox and will be tested as part of the flow routing routines. However, it is good to run them to make sure the bindings work before we have the whole flow routing setup.