### PR TITLE
Drop support for numpy versions less than 2.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,12 +33,6 @@ jobs:
       - name: Run tests
         run: |
           python -m pytest
-
-      - name: Downgrade numpy
-        if: ${{ matrix.python-version <= '3.11' }}
-        run: |
-          pip install matplotlib scipy rasterio pandas geopandas "numpy==1.23.5" --upgrade --upgrade-strategy eager
-          pytest
   lint:
     runs-on: ubuntu-latest
     strategy:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ description = "Python interface to TopoToolbox."
 readme = "README.md"
 license = { file = "LICENSE" }
 dependencies = [
-    "numpy>=1.23.5",
+    "numpy>=2.0.0",
     "matplotlib",
     "scipy",
     "rasterio",


### PR DESCRIPTION
See https://scientific-python.org/specs/spec-0000/

We are well into the SPEC0 support window for Numpy v2.x and all versions 1.x are out of the support window.

pytopotoolbox may continue to run on older versions of Numpy. This change only means that we won't continue to test on older versions.