### PR TITLE
Return Boolean arrays from influencemap and dependencemap

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ include(FetchContent)
 FetchContent_Declare(
   topotoolbox
   GIT_REPOSITORY https://github.com/TopoToolbox/libtopotoolbox.git
-  GIT_TAG be68210064ac0ebe9c3328873099401540b63aa3
+  GIT_TAG cb81ee36a5268445840ccb29e00f47533eadc681
 )
 FetchContent_MakeAvailable(topotoolbox)
 

--- a/src/lib/stream.cpp
+++ b/src/lib/stream.cpp
@@ -83,6 +83,38 @@ void wrap_traverse_down_u32_or_and(py::array_t<uint32_t> output,
                            target_ptr, edge_count);
 }
 
+void wrap_traverse_up_u8_or_and(py::array_t<uint8_t> output,
+                                py::array_t<uint8_t> input,
+                                py::array_t<ptrdiff_t> source,
+                                py::array_t<ptrdiff_t> target) {
+
+  uint8_t *output_ptr = output.mutable_data();
+  uint8_t *input_ptr = input.mutable_data();
+  ptrdiff_t *source_ptr = source.mutable_data();
+  ptrdiff_t *target_ptr = target.mutable_data();
+
+  ptrdiff_t edge_count = source.size();
+
+  traverse_up_u8_or_and(output_ptr, input_ptr, source_ptr,
+                        target_ptr, edge_count);
+}
+
+void wrap_traverse_down_u8_or_and(py::array_t<uint8_t> output,
+                                   py::array_t<uint8_t> input,
+                                   py::array_t<ptrdiff_t> source,
+                                   py::array_t<ptrdiff_t> target) {
+
+  uint8_t *output_ptr = output.mutable_data();
+  uint8_t *input_ptr = input.mutable_data();
+  ptrdiff_t *source_ptr = source.mutable_data();
+  ptrdiff_t *target_ptr = target.mutable_data();
+
+  ptrdiff_t edge_count = source.size();
+
+  traverse_down_u8_or_and(output_ptr, input_ptr, source_ptr,
+                          target_ptr, edge_count);
+}
+
 void wrap_traverse_down_f32_max_add(py::array_t<float> output,
                                     py::array_t<float> input,
                                     py::array_t<ptrdiff_t> source,
@@ -319,6 +351,8 @@ PYBIND11_MODULE(_stream, m) {
   m.def("streamquad_trapz_f64", &wrap_streamquad_trapz_f64);
   m.def("traverse_up_u32_or_and", &wrap_traverse_up_u32_or_and);
   m.def("traverse_down_u32_or_and", &wrap_traverse_down_u32_or_and);
+  m.def("traverse_up_u8_or_and", &wrap_traverse_up_u8_or_and);
+  m.def("traverse_down_u8_or_and", &wrap_traverse_down_u8_or_and);
   m.def("traverse_down_f32_max_add", &wrap_traverse_down_f32_max_add);
   m.def("traverse_up_f32_max_add", &wrap_traverse_up_f32_max_add);
   m.def("traverse_down_f32_max_mul", &wrap_traverse_down_f32_max_mul);

--- a/src/topotoolbox/flow_object.py
+++ b/src/topotoolbox/flow_object.py
@@ -540,13 +540,13 @@ class FlowObject():
         """
 
         # convert input argument to correct units
-        seed = self.ezgetnal(l, dtype = np.uint32)
+        seed = self.ezgetnal(l, dtype = np.uint8)
 
         # graph traversal algorithm
-        i = np.ones(self.source.shape, dtype = np.uint32, order=self.order) # turns on all edges
-        _stream.traverse_up_u32_or_and(seed, i, self.source, self.target)
+        i = np.ones(self.source.shape, dtype = np.uint8, order=self.order) # turns on all edges
+        _stream.traverse_up_u8_or_and(seed, i, self.source, self.target)
 
-        return l.duplicate_with_new_data(np.asarray(seed))
+        return l.duplicate_with_new_data(np.asarray(seed, dtype=np.bool))
 
     def influencemap(self, l) -> GridObject:
         """Delineate downslope area for specific locations in a DEM.
@@ -564,13 +564,13 @@ class FlowObject():
         """
 
         # convert input argument to correct units
-        seed = self.ezgetnal(l, dtype = np.uint32)
+        seed = self.ezgetnal(l, dtype = np.uint8)
 
         # graph traversal algorithm
-        i = np.ones(self.source.shape, dtype = np.uint32, order=self.order) # turns on all edges
-        _stream.traverse_down_u32_or_and(seed, i, self.source, self.target)
+        i = np.ones(self.source.shape, dtype = np.uint8, order=self.order) # turns on all edges
+        _stream.traverse_down_u8_or_and(seed, i, self.source, self.target)
 
-        return l.duplicate_with_new_data(np.asarray(seed))
+        return l.duplicate_with_new_data(np.asarray(seed, dtype=np.bool))
 
     # 'Magic' functions:
     # ------------------------------------------------------------------------

--- a/tests/test_flow_object.py
+++ b/tests/test_flow_object.py
@@ -301,6 +301,32 @@ def test_upstream_distance_order(order_dems):
 
     assert np.array_equal(cd, fd)
 
+# Issue #424: make sure that indexing with the return value of
+# dependencemap and influencemap returns a subset of the given
+# array. Also check to make sure that dependencemap and influencemap
+# actually propagate values up and downstream by making sure there are
+# active pixels that are not part of the original mask
+def test_dependence_map_indexing(wide_dem):
+    fd = topo.FlowObject(wide_dem)
+
+    mask = wide_dem.z == np.min(wide_dem)
+
+    l = wide_dem.duplicate_with_new_data(mask)
+    d = fd.dependencemap(l)
+    assert np.any(d.z & np.invert(mask))
+    assert wide_dem.z[d.z].size < wide_dem.z.size
+
+def test_influence_map_indexing(wide_dem):
+    fd = topo.FlowObject(wide_dem)
+
+    mask = wide_dem.z == np.max(wide_dem)
+
+    l = wide_dem.duplicate_with_new_data(mask)
+    i = fd.influencemap(l)
+
+    assert np.any(i.z & np.invert(mask))
+    assert wide_dem.z[i.z].size < wide_dem.z.size
+
 def test_dependence_map_order(order_dems):
     cdem, fdem = order_dems
     l_c = cdem.duplicate_with_new_data(np.zeros(cdem.shape, dtype = bool, order = 'C'))


### PR DESCRIPTION
Resolves #424

Numpy handles indexing with Boolean arrays differently than integer arrays. For masking, the correct behavior is the Boolean indexing, and since `influencemap` and `dependencemap` are fundamentally masks, they need to return logical arrays.

They are both updated to use libtopotoolbox's new
`traverse_down_u8_or_and` and the seed pixels are extracted as np.uint8. The seed array then copied to type bool before being returned.

We cannot use arrays of type bool throughout because libtopotoolbox expects arrays of type uint8_t, and while Numpy may internally store its Boolean arrays as arrays of bytes, pybind11 will copies the bool array to a uint8_t array to pass it to the wrapper function, and the output array is not filled properly. We could explicitly add a traversal with type `bool` to libtopotoolbox, but the `bool` type is somewhat unstable in C compared to C++, and I would prefer to use explicitly sized types for input and output data of the traversals.

Tests have been added to ensure that

1. `influencemap` and `dependencemap` propagate values down and upstream. This will fail if the output array is not filled.
2. Indexing with their outputs returns a subset of pixels..