### PR TITLE
Wrap and test flow_routing_d8_directions and flow_routing_d8_weights

### DIFF
--- a/src/lib/flow.cpp
+++ b/src/lib/flow.cpp
@@ -64,10 +64,32 @@ void wrap_flow_routing_tsort(
                      edge_count, dims, order);
 }
 
+void wrap_flow_routing_d8_directions(py::array_t<uint8_t> direction,
+                                     py::array_t<float> dem) {
+
+  int order = direction.flags() & py::array::c_style ? 1 : 0;
+  ptrdiff_t dims[2] = {dem.shape(0), dem.shape(1)};
+  // Reverse the dimensions if in row-major order
+  if (order) {
+    dims[0] = dem.shape(1);
+    dims[1] = dem.shape(0);
+  }
+
+  flow_routing_d8_directions(direction.mutable_data(), dem.mutable_data(),
+                             dims, order);
+}
+
+void wrap_flow_routing_d8_weights(py::array_t<float> weight) {
+  ptrdiff_t count = weight.size();
+  flow_routing_d8_weights(weight.mutable_data(), count);
+}
+
 PYBIND11_MODULE(_flow, m) {
   m.def("edgeset_count", &wrap_edgeset_count);
   m.def("edgeset_scan", &wrap_edgeset_scan);
   m.def("edgeset_count_merged", &wrap_edgeset_count_merged);
   m.def("edgeset_merge", &wrap_edgeset_merge);
   m.def("flow_routing_tsort", &wrap_flow_routing_tsort);
+  m.def("flow_routing_d8_directions", &wrap_flow_routing_d8_directions);
+  m.def("flow_routing_d8_weights", &wrap_flow_routing_d8_weights);
 }

--- a/tests/test_edgeset.py
+++ b/tests/test_edgeset.py
@@ -6,9 +6,13 @@ import topotoolbox as tt3
 
 rng = np.random.default_rng(210057042403268582692858923958297081890)
 
-def bitmap():
-    sz = (3, 5)
-    z = np.array(rng.random(sz))
+@pytest.fixture
+def dem():
+    sz = (11, 13)
+    return rng.random(sz)
+
+def bitmap(z):
+    sz = z.shape
     edges = np.zeros(sz, dtype=np.uint8)
 
     ei = np.array([0, -1, -1, -1, 0, 1, 1, 1])
@@ -25,12 +29,12 @@ def bitmap():
     return edges
 
 @pytest.fixture
-def bitmap1():
-    return bitmap()
+def bitmap1(dem):
+    return bitmap(dem)
 
 @pytest.fixture
-def bitmap2():
-    return bitmap()
+def bitmap2(dem):
+    return bitmap(dem)
 
 def uniform_weights(bitmap):
     np.seterr(divide='ignore')
@@ -107,3 +111,37 @@ def test_edgeset_tsort(bitmap1):
     # edge, but it should have the same weight.
     for (u, w) in zip(source, sweight):
         assert w == weights1[scan[np.unravel_index(u, scan.shape)]]
+
+def test_flow_routing_d8(dem):
+    directions = np.zeros(dem.shape, dtype=np.uint8)
+    tt3._flow.flow_routing_d8_directions(directions, dem)
+
+    assert np.all(np.bitwise_count(directions) < 2)
+
+    scan = np.zeros(dem.shape, dtype=np.int64)
+    c = tt3._flow.edgeset_scan(scan, directions)
+
+    assert c > 0
+
+    weights = np.zeros(c, dtype=np.float32)
+    tt3._flow.flow_routing_d8_weights(weights)
+
+    stream = np.zeros(dem.shape, dtype=np.int64)
+    source = np.zeros(c, dtype=np.int64)
+    target = np.zeros(c, dtype=np.int64)
+    sweight= np.zeros(c, dtype=np.float32)
+
+    stack = np.zeros(dem.shape, dtype=np.int64)
+    stackdir = np.zeros(dem.shape, dtype=np.uint8)
+    visited = np.zeros(dem.shape, dtype=np.uint8)
+
+    tt3._flow.flow_routing_tsort(stream, source, target, sweight,
+                                 stack, stackdir, directions, weights, scan, visited)
+
+    assert np.all(sweight == 1.0)
+
+    visited[:] = 0
+    for (u, v) in zip(source, target):
+        visited[np.unravel_index(u, dem.shape)] += 1
+
+        assert visited[np.unravel_index(v, dem.shape)] == 0


### PR DESCRIPTION
See #421

These implement D8 flow routing without flat resolution.

A test has been added to test_edgeset.py to make sure that this binding works and results in a valid directed acyclic graph for the random input.