### PR TITLE
Wrap and test resolve_flats_lcat

### DIFF
--- a/src/lib/flow.cpp
+++ b/src/lib/flow.cpp
@@ -84,6 +84,29 @@ void wrap_flow_routing_d8_weights(py::array_t<float> weight) {
   flow_routing_d8_weights(weight.mutable_data(), count);
 }
 
+void wrap_resolve_flats_lcat(py::array_t<uint8_t> direction,
+                             py::array_t<uint8_t> resolved,
+                             py::array_t<float> aux,
+                             py::array_t<float> dem) {
+
+  int order = direction.flags() & py::array::c_style ? 1 : 0;
+  ptrdiff_t dims[2] = {dem.shape(0), dem.shape(1)};
+  // Reverse the dimensions if in row-major order
+  if (order) {
+    dims[0] = dem.shape(1);
+    dims[1] = dem.shape(0);
+  }
+
+  resolve_flats_lcat(direction.mutable_data(), resolved.mutable_data(),
+                     aux.mutable_data(), dem.mutable_data(), dims, order);
+}
+
+void wrap_resolve_flats_lcat_weights(py::array_t<float> weight) {
+  ptrdiff_t count = weight.size();
+
+  resolve_flats_lcat_weights(weight.mutable_data(), count);
+}
+
 PYBIND11_MODULE(_flow, m) {
   m.def("edgeset_count", &wrap_edgeset_count);
   m.def("edgeset_scan", &wrap_edgeset_scan);
@@ -92,4 +115,6 @@ PYBIND11_MODULE(_flow, m) {
   m.def("flow_routing_tsort", &wrap_flow_routing_tsort);
   m.def("flow_routing_d8_directions", &wrap_flow_routing_d8_directions);
   m.def("flow_routing_d8_weights", &wrap_flow_routing_d8_weights);
+  m.def("resolve_flats_lcat", &wrap_resolve_flats_lcat);
+  m.def("resolve_flats_lcat_weights", &wrap_resolve_flats_lcat_weights);
 }

--- a/tests/test_edgeset.py
+++ b/tests/test_edgeset.py
@@ -9,7 +9,7 @@ rng = np.random.default_rng(210057042403268582692858923958297081890)
 @pytest.fixture
 def dem():
     sz = (11, 13)
-    return rng.random(sz)
+    return rng.random(sz, dtype=np.float32)
 
 def bitmap(z):
     sz = z.shape
@@ -145,3 +145,75 @@ def test_flow_routing_d8(dem):
         visited[np.unravel_index(u, dem.shape)] += 1
 
         assert visited[np.unravel_index(v, dem.shape)] == 0
+
+def test_resolve_flats_lcat(dem):
+    dims = (dem.shape[1], dem.shape[0])
+    demf = np.zeros(dem.shape, dtype=np.float32)
+    bc = np.ones_like(dem, dtype=np.uint8)
+    bc[1:-1, 1:-1] = 0
+
+    tt3._grid.fillsinks(demf, dem, bc, dims)
+
+    flats = np.zeros_like(dem, dtype=np.int32)
+    tt3._grid.identifyflats(flats, demf, dims)
+
+    costs = np.zeros_like(dem, dtype=np.float32)
+    conncomps = np.zeros_like(dem, dtype=np.int64)
+    tt3._grid.gwdt_computecosts(costs, conncomps, flats, dem, demf, dims)
+
+    aux  = np.zeros_like(flats, dtype=np.float32)
+    prev = np.zeros_like(flats, dtype=np.int64)
+    heap = np.zeros_like(flats, dtype=np.int64)
+    back = np.zeros_like(flats, dtype=np.int64)
+    tt3._grid.gwdt(aux, prev, costs, flats, heap, back, dims)
+
+    direction = np.zeros(dem.shape, dtype=np.uint8)
+    tt3._flow.flow_routing_d8_directions(direction, demf)
+
+    scan = np.zeros(dem.shape, dtype=np.int64)
+    c = tt3._flow.edgeset_scan(scan, direction)
+
+    weights = np.zeros(c, dtype=np.float32)
+    tt3._flow.flow_routing_d8_weights(weights)
+
+    rdirection = np.zeros(dem.shape, dtype=np.uint8)
+    resolved = flats & 1 == 0
+
+    assert not np.all(resolved)
+
+    tt3._flow.resolve_flats_lcat(rdirection, resolved, aux, demf)
+
+    cr = tt3._flow.edgeset_count(rdirection)
+
+    rweights = np.zeros(cr, dtype=np.float32)
+    tt3._flow.resolve_flats_lcat_weights(rweights)
+
+    c2 = tt3._flow.edgeset_count_merged(rdirection, direction)
+
+    mweights = np.zeros(c2, dtype=np.float32)
+    mscan = np.zeros(dem.shape, dtype=np.int64)
+    tt3._flow.edgeset_merge(mweights, mscan, direction, weights, rdirection, rweights)
+
+    stream = np.zeros(dem.shape, dtype=np.int64)
+    source = np.zeros(c2, dtype=np.int64)
+    target = np.zeros(c2, dtype=np.int64)
+    sweight = np.zeros(c2, dtype=np.float32)
+
+    stack = np.zeros(dem.shape, dtype=np.int64)
+    stackdir = np.zeros(dem.shape, dtype=np.uint8)
+    visited = np.zeros(dem.shape, dtype=np.uint8)
+
+    tt3._flow.flow_routing_tsort(stream, source, target,
+                                 sweight, stack, stackdir,
+                                 direction, mweights, mscan, visited)
+
+    assert np.all(sweight == 1.0)
+
+    visited[:] = 0
+    for (u, v) in zip(source, target):
+        visited[np.unravel_index(u, dem.shape)] += 1
+
+        assert visited[np.unravel_index(v, dem.shape)] == 0
+
+    # All pixels with no outgoing edges should be on the boundary
+    assert np.all(bc[visited == 0] == 1)


### PR DESCRIPTION
The added test runs through the process for D8 flow routing with LCAT carving, and it checks to make sure that the topological sort is correct.