### PR TITLE
Add D8 flow routing using new libtopotoolbox interface

### DIFF
--- a/src/topotoolbox/flow_object.py
+++ b/src/topotoolbox/flow_object.py
@@ -75,6 +75,84 @@ class EdgeSet:
 
         return (stream, source, target, sweight)
 
+def _d8(dem: np.ndarray) -> EdgeSet:
+    """Route flow over the provided DEM with D8
+    """
+    z = np.asarray(dem, dtype=np.float32)
+    directions = np.zeros_like(z, dtype=np.uint8)
+    _flow.flow_routing_d8_directions(directions, z)
+
+    scan = np.zeros_like(z, dtype=np.int64)
+    c = _flow.edgeset_scan(scan, directions)
+
+    weights = np.zeros(c, dtype=np.float32)
+    _flow.flow_routing_d8_weights(weights)
+
+    return EdgeSet(directions, scan, weights)
+
+def _lcat(aux: np.ndarray, demf: np.ndarray, flats: np.ndarray) -> EdgeSet:
+    """Route flow over the provided DEM and auxiliary topography using
+    least cost auxiliary topography carving
+    """
+    directions = np.zeros_like(demf, dtype=np.uint8)
+    resolved = flats & 1 == 0
+
+    _flow.resolve_flats_lcat(directions, resolved, aux, demf)
+
+    scan = np.zeros_like(demf, dtype=np.int64)
+    cr = _flow.edgeset_scan(scan, directions)
+
+    weights = np.zeros(cr, dtype=np.float32)
+    _flow.resolve_flats_lcat_weights(weights)
+
+    return EdgeSet(directions, scan, weights)
+
+def _d8_carve(grid: GridObject,
+             bc: np.ndarray | GridObject | None = None,
+             hybrid: bool = True):
+    """Construct a FlowObject using D8 flow routing with least
+        cost auxiliary topography carving.
+
+    Parameters
+    ----------
+    grid : GridObject
+        The GridObject that will be the basis of the computation.
+    bc : ndarray or GridObject, optional
+        Boundary conditions for sink filling. `bc` should be an array
+        of np.uint8 that matches the shape of the DEM. Values of 1
+        indicate pixels that should be fixed to their values in the
+        original DEM and values of 0 indicate pixels that should be
+        filled.
+    hybrid: bool, optional
+        Should hybrid reconstruction algorithm be used to fill
+        sinks? Defaults to True. Hybrid reconstruction is faster
+        but requires additional memory be allocated for a queue.
+
+    Notes
+    -----
+    Large intermediate arrays are created during the initialization
+    process, which could lead to issues when using very large DEMs.
+    """
+    dims = grid.dims
+
+    (aux, filled_dem, flats) = grid.auxiliary_topography(bc, hybrid)
+
+    node = np.zeros_like(aux, dtype=np.int64)  # node: dtype=np.int64
+    direction = np.zeros_like(aux, dtype=np.uint8)
+    _grid.flow_routing_d8_carve(node, direction, filled_dem, aux, flats, dims)
+
+    # ravel is used here to flatten the arrays. The memory order should not matter
+    # because we only need a block of contiguous memory interpreted as a 1D array.
+    source = np.zeros(aux.size, dtype=np.int64)  # source: dtype=int64
+    target = np.zeros(aux.size, dtype=np.int64)       # target: dtype=int64
+    edge_count = _grid.flow_routing_d8_edgelist(source, target, node, direction, dims)
+
+    return (direction,
+            node,
+            source[0:edge_count],
+            target[0:edge_count],
+            np.ones(edge_count, dtype=np.float32))
+
 class FlowObject():
     """A class containing containing (water-) flow information about a given
     digital elevation model (DEM).
@@ -82,7 +160,9 @@ class FlowObject():
 
     def __init__(self, grid: GridObject,
                  bc: np.ndarray | GridObject | None = None,
-                 method: str = "d8", **kwargs):
+                 method: str = "d8",
+                 sink_resolution: str = "carve",
+                 **kwargs):
         """The constructor for the FlowObject. Takes a GridObject as input,
         computes flow direction information and saves them as an FlowObject.
 
@@ -98,6 +178,9 @@ class FlowObject():
             filled.
         method : str, optional
             The flow routing method to use. Currently supported methods include "d8".
+        sink_resolution: str, optional
+            The sink resolution method to use. Currently supported
+            methods are "carve" and "lcat". The default is "carve".
 
         Raises
         ------
@@ -111,61 +194,24 @@ class FlowObject():
         >>> flow = topotoolbox.FlowObject(dem)
         """
         if method == "d8":
-            self._d8_carve(grid, bc, **kwargs)
+            if sink_resolution == "carve":
+                (direction, stream, source, target, sweight) = _d8_carve(grid, bc, **kwargs)
+            elif sink_resolution == "lcat":
+                aux, demf, flats = grid.auxiliary_topography(bc)
+                e1 = _d8(demf)
+                e2 = _lcat(aux, demf, flats)
+
+                em = e1.merge(e2)
+                direction = em.directions
+
+                (stream, source, target, sweight) = em.tsort()
+            else:
+                raise ValueError(f" Sink resolution {method} is not supported")
         else:
             raise ValueError(f"Flow routing {method} is not supported")
 
-    def _d8_carve(self,
-                 grid: GridObject,
-                 bc: np.ndarray | GridObject | None = None,
-                 hybrid: bool = True):
-        """Construct a FlowObject using D8 flow routing with least
-        cost auxiliary topography carving.
-
-        Parameters
-        ----------
-        grid : GridObject
-            The GridObject that will be the basis of the computation.
-        bc : ndarray or GridObject, optional
-            Boundary conditions for sink filling. `bc` should be an array
-            of np.uint8 that matches the shape of the DEM. Values of 1
-            indicate pixels that should be fixed to their values in the
-            original DEM and values of 0 indicate pixels that should be
-            filled.
-        hybrid: bool, optional
-            Should hybrid reconstruction algorithm be used to fill
-            sinks? Defaults to True. Hybrid reconstruction is faster
-            but requires additional memory be allocated for a queue.
-
-        Notes
-        -----
-        Large intermediate arrays are created during the initialization
-        process, which could lead to issues when using very large DEMs.
-        """
-        dims = grid.dims
-
-        (aux, filled_dem, flats) = grid.auxiliary_topography(bc, hybrid)
-
-        node = np.zeros_like(aux, dtype=np.int64)  # node: dtype=np.int64
-        direction = np.zeros_like(aux, dtype=np.uint8)
-        _grid.flow_routing_d8_carve(
-            node, direction, filled_dem, aux, flats, dims)
-
-        # ravel is used here to flatten the arrays. The memory order should not matter
-        # because we only need a block of contiguous memory interpreted as a 1D array.
-        source = np.zeros(aux.size, dtype=np.int64)  # source: dtype=int64
-        target = np.zeros(aux.size, dtype=np.int64)       # target: dtype=int64
-        edge_count = _grid.flow_routing_d8_edgelist(
-            source, target, node, direction, dims)
-
         self.path = grid.path
         self.name = grid.name
-
-        self.direction = direction  # dtype=np.unit8
-
-        self.stream = node
-        self.source = source[0:edge_count]  # dtype=np.int64
-        self.target = target[0:edge_count]  # dtype=np.int64
 
         self.shape = grid.shape
         self.cellsize = grid.cellsize
@@ -176,6 +222,12 @@ class FlowObject():
         self.bounds = grid.bounds
         self.transform = grid.transform
         self.georef = grid.georef
+
+        self.direction = direction
+        self.stream = stream
+        self.source = source
+        self.target = target
+        self.fraction = sweight
 
     @property
     def dims(self):

--- a/tests/test_edgeset.py
+++ b/tests/test_edgeset.py
@@ -9,7 +9,10 @@ rng = np.random.default_rng(210057042403268582692858923958297081890)
 @pytest.fixture
 def dem():
     sz = (11, 13)
-    return rng.random(sz, dtype=np.float32)
+    z = tt3.GridObject()
+    z.z = rng.random(sz, dtype=np.float32)
+    z.cellsize = 1.0
+    return z
 
 def bitmap(z):
     sz = z.shape
@@ -89,91 +92,3 @@ def test_edgeset_tsort(edgeset1):
     # first outgoing edge of each source. This may not be the same
     # edge, but it should have the same weight.
     assert np.array_equal(sweight, edgeset1.weights[edgeset1.scan[np.unravel_index(source, edgeset1.shape)]])
-
-def test_flow_routing_d8(dem):
-    directions = np.zeros(dem.shape, dtype=np.uint8)
-    tt3._flow.flow_routing_d8_directions(directions, dem)
-
-    assert np.all(np.bitwise_count(directions) < 2)
-
-    scan = np.zeros(dem.shape, dtype=np.int64)
-    c = tt3._flow.edgeset_scan(scan, directions)
-
-    assert c > 0
-
-    weights = np.zeros(c, dtype=np.float32)
-    tt3._flow.flow_routing_d8_weights(weights)
-
-    edges = tt3.EdgeSet(directions, scan, weights)
-
-    (stream, source, target, sweight) = edges.tsort()
-
-    assert np.all(sweight == 1.0)
-
-    visited = np.zeros_like(directions)
-    for (u, v) in zip(source, target):
-        visited[np.unravel_index(u, dem.shape)] += 1
-
-        assert visited[np.unravel_index(v, dem.shape)] == 0
-
-def test_resolve_flats_lcat(dem):
-    dims = (dem.shape[1], dem.shape[0])
-    demf = np.zeros(dem.shape, dtype=np.float32)
-    bc = np.ones_like(dem, dtype=np.uint8)
-    bc[1:-1, 1:-1] = 0
-
-    tt3._grid.fillsinks(demf, dem, bc, dims)
-
-    flats = np.zeros_like(dem, dtype=np.int32)
-    tt3._grid.identifyflats(flats, demf, dims)
-
-    costs = np.zeros_like(dem, dtype=np.float32)
-    conncomps = np.zeros_like(dem, dtype=np.int64)
-    tt3._grid.gwdt_computecosts(costs, conncomps, flats, dem, demf, dims)
-
-    aux  = np.zeros_like(flats, dtype=np.float32)
-    prev = np.zeros_like(flats, dtype=np.int64)
-    heap = np.zeros_like(flats, dtype=np.int64)
-    back = np.zeros_like(flats, dtype=np.int64)
-    tt3._grid.gwdt(aux, prev, costs, flats, heap, back, dims)
-
-    direction = np.zeros(dem.shape, dtype=np.uint8)
-    tt3._flow.flow_routing_d8_directions(direction, demf)
-
-    scan = np.zeros(dem.shape, dtype=np.int64)
-    c = tt3._flow.edgeset_scan(scan, direction)
-
-    weights = np.zeros(c, dtype=np.float32)
-    tt3._flow.flow_routing_d8_weights(weights)
-
-    e1 = tt3.EdgeSet(direction, scan, weights)
-
-    rdirection = np.zeros(dem.shape, dtype=np.uint8)
-    resolved = flats & 1 == 0
-
-    assert not np.all(resolved)
-
-    tt3._flow.resolve_flats_lcat(rdirection, resolved, aux, demf)
-
-    rscan = np.zeros(dem.shape, dtype=np.int64)
-    cr = tt3._flow.edgeset_scan(rscan, rdirection)
-
-    rweights = np.zeros(cr, dtype=np.float32)
-    tt3._flow.resolve_flats_lcat_weights(rweights)
-
-    e2 = tt3.EdgeSet(rdirection, rscan, rweights)
-
-    em = e1.merge(e2)
-
-    (stream, source, target, sweight) = em.tsort()
-
-    assert np.all(sweight == 1.0)
-
-    visited = np.zeros_like(direction)
-    for (u, v) in zip(source, target):
-        visited[np.unravel_index(u, dem.shape)] += 1
-
-        assert visited[np.unravel_index(v, dem.shape)] == 0
-
-    # All pixels with no outgoing edges should be on the boundary
-    assert np.all(bc[visited == 0] == 1)

--- a/tests/test_flow_object.py
+++ b/tests/test_flow_object.py
@@ -37,11 +37,12 @@ def order_dems():
 
     return [cdem, fdem]
 
-
-def test_flowobject(wide_dem):
+@pytest.mark.parametrize("method", ["d8"])
+@pytest.mark.parametrize("sink_resolution", ["carve", "lcat"])
+def test_flowobject(wide_dem, method, sink_resolution):
     dem = wide_dem
     original_dem = dem.z.copy()
-    fd = topo.FlowObject(dem)
+    fd = topo.FlowObject(dem, method=method, sink_resolution=sink_resolution)
 
     assert topo.validate_alignment(dem, fd)
 
@@ -57,21 +58,34 @@ def test_flowobject(wide_dem):
     # Ensure that FlowObject does not modify the original DEM
     assert np.all(dem.z == original_dem)
 
+    visited = np.zeros_like(dem, dtype=np.uint8)
+    for (u, v) in zip(fd.source, fd.target):
+        visited[np.unravel_index(u, dem.shape)] += 1
 
-def test_flowobject_order(order_dems):
+        assert visited[np.unravel_index(v, dem.shape)] == 0
+
+    # All pixels with no outgoing edges should be on the boundary
+    bc = np.ones_like(dem, dtype=np.uint8)
+    bc[1:-1, 1:-1] = 0
+    assert np.all(bc[visited == 0] == 1)
+
+@pytest.mark.parametrize("method", ["d8"])
+@pytest.mark.parametrize("sink_resolution", ["carve", "lcat"])
+def test_flowobject_order(order_dems, method, sink_resolution):
     cdem, fdem = order_dems
 
-    cfd = topo.FlowObject(cdem)
-    ffd = topo.FlowObject(fdem)
+    cfd = topo.FlowObject(cdem, method=method, sink_resolution=sink_resolution)
+    ffd = topo.FlowObject(fdem, method=method, sink_resolution=sink_resolution)
 
     assert isequivalent(cfd, ffd)
 
-
-def test_flow_accumulation_order(order_dems):
+@pytest.mark.parametrize("method", ["d8"])
+@pytest.mark.parametrize("sink_resolution", ["carve", "lcat"])
+def test_flow_accumulation_order(order_dems, method, sink_resolution):
     cdem, fdem = order_dems
 
-    cfd = topo.FlowObject(cdem)
-    ffd = topo.FlowObject(fdem)
+    cfd = topo.FlowObject(cdem, method=method, sink_resolution=sink_resolution)
+    ffd = topo.FlowObject(fdem, method=method, sink_resolution=sink_resolution)
 
     ca = cfd.flow_accumulation()
     fa = ffd.flow_accumulation()
@@ -79,11 +93,13 @@ def test_flow_accumulation_order(order_dems):
     assert np.array_equal(ca, fa)
 
 
-def test_drainagebasins_order(order_dems):
+@pytest.mark.parametrize("method", ["d8"])
+@pytest.mark.parametrize("sink_resolution", ["carve", "lcat"])
+def test_drainagebasins_order(order_dems, method, sink_resolution):
     cdem, fdem = order_dems
 
-    cfd = topo.FlowObject(cdem)
-    ffd = topo.FlowObject(fdem)
+    cfd = topo.FlowObject(cdem, method=method, sink_resolution=sink_resolution)
+    ffd = topo.FlowObject(fdem, method=method, sink_resolution=sink_resolution)
 
     cdb = cfd.drainagebasins()
     fdb = ffd.drainagebasins()
@@ -132,8 +148,10 @@ def test_drainagebasins_order(order_dems):
     assert np.array_equal(crec.flatten(), cdb.z.flatten())
 
 
-def test_ezgetnal(wide_dem):
-    fd = topo.FlowObject(wide_dem)
+@pytest.mark.parametrize("method", ["d8"])
+@pytest.mark.parametrize("sink_resolution", ["carve", "lcat"])
+def test_ezgetnal(wide_dem, method, sink_resolution):
+    fd = topo.FlowObject(wide_dem, method=method, sink_resolution=sink_resolution)
 
     z = fd.ezgetnal(wide_dem)
     z2 = fd.ezgetnal(z.z)
@@ -156,9 +174,10 @@ def test_ezgetnal(wide_dem):
     # ezgetnal with dtype should return array of that dtype
     assert z3.z.dtype is np.dtype(np.float64)
 
-
-def test_flowpathextract(wide_dem):
-    fd = topo.FlowObject(wide_dem)
+@pytest.mark.parametrize("method", ["d8"])
+@pytest.mark.parametrize("sink_resolution", ["carve", "lcat"])
+def test_flowpathextract(wide_dem, method, sink_resolution):
+    fd = topo.FlowObject(wide_dem, method=method, sink_resolution=sink_resolution)
     s = topo.StreamObject(fd)
 
     assert topo.validate_alignment(wide_dem, fd)
@@ -188,11 +207,13 @@ def test_flowpathextract(wide_dem):
             assert idxs[e] == u
             assert idxs[e + 1] == v
 
-def test_flowpathextract_order(order_dems):
+@pytest.mark.parametrize("method", ["d8"])
+@pytest.mark.parametrize("sink_resolution", ["carve", "lcat"])
+def test_flowpathextract_order(order_dems, method, sink_resolution):
     cdem, fdem = order_dems
 
-    cfd = topo.FlowObject(cdem)
-    ffd = topo.FlowObject(fdem)
+    cfd = topo.FlowObject(cdem, method=method, sink_resolution=sink_resolution)
+    ffd = topo.FlowObject(fdem, method=method, sink_resolution=sink_resolution)
 
     # Convert the row-major linear index to column-major
     ci = np.ravel_multi_index((37, 109), cfd.shape, order=cfd.order)
@@ -207,11 +228,13 @@ def test_flowpathextract_order(order_dems):
 
     assert np.array_equal(cp, fpc)
 
-def test_distance_order(order_dems):
+@pytest.mark.parametrize("method", ["d8"])
+@pytest.mark.parametrize("sink_resolution", ["carve", "lcat"])
+def test_distance_order(order_dems, method, sink_resolution):
     cdem, fdem = order_dems
 
-    cfd = topo.FlowObject(cdem)
-    ffd = topo.FlowObject(fdem)
+    cfd = topo.FlowObject(cdem, method=method, sink_resolution=sink_resolution)
+    ffd = topo.FlowObject(fdem, method=method, sink_resolution=sink_resolution)
 
     cd = cfd.node_to_node_distance()
     fd = ffd.node_to_node_distance()
@@ -224,9 +247,11 @@ def test_distance_order(order_dems):
 
     assert np.array_equal(cdg, fdg)
 
-def test_imposemin(wide_dem):
+@pytest.mark.parametrize("method", ["d8"])
+@pytest.mark.parametrize("sink_resolution", ["carve", "lcat"])
+def test_imposemin(wide_dem, method, sink_resolution):
     original_dem = wide_dem.z.copy()
-    fd = topo.FlowObject(wide_dem)
+    fd = topo.FlowObject(wide_dem, method=method, sink_resolution=sink_resolution)
 
     g0 = (wide_dem.z[fd.source_indices] -
           wide_dem.z[fd.target_indices])/fd.node_to_node_distance()
@@ -249,11 +274,12 @@ def test_imposemin(wide_dem):
         # imposemin should not modify the original array
         assert np.array_equal(original_dem, wide_dem.z)
 
-
-def test_imposemin_f64(wide_dem):
+@pytest.mark.parametrize("method", ["d8"])
+@pytest.mark.parametrize("sink_resolution", ["carve", "lcat"])
+def test_imposemin_f64(wide_dem, method, sink_resolution):
     original_dem = np.array(wide_dem, dtype=np.float64)
 
-    fd = topo.FlowObject(wide_dem)
+    fd = topo.FlowObject(wide_dem, method=method, sink_resolution=sink_resolution)
 
     z = np.array(wide_dem.z, dtype=np.float64)
 
@@ -268,33 +294,39 @@ def test_imposemin_f64(wide_dem):
     # imposemin should not modify the original array
     assert np.array_equal(original_dem, z)
 
-def test_imposemin_order(order_dems):
+@pytest.mark.parametrize("method", ["d8"])
+@pytest.mark.parametrize("sink_resolution", ["carve", "lcat"])
+def test_imposemin_order(order_dems, method, sink_resolution):
     cdem, fdem = order_dems
 
-    cfd = topo.FlowObject(cdem)
-    ffd = topo.FlowObject(fdem)
+    cfd = topo.FlowObject(cdem, method=method, sink_resolution=sink_resolution)
+    ffd = topo.FlowObject(fdem, method=method, sink_resolution=sink_resolution)
 
     cminslope = topo.imposemin(cfd, cdem, minimum_slope=0.001)
     fminslope = topo.imposemin(ffd, fdem, minimum_slope=0.001)
 
     assert np.array_equal(cminslope, fminslope)
 
-def test_downstream_distance_order(order_dems):
+@pytest.mark.parametrize("method", ["d8"])
+@pytest.mark.parametrize("sink_resolution", ["carve", "lcat"])
+def test_downstream_distance_order(order_dems, method, sink_resolution):
     cdem, fdem = order_dems
 
-    cfd = topo.FlowObject(cdem)
-    ffd = topo.FlowObject(fdem)
+    cfd = topo.FlowObject(cdem, method=method, sink_resolution=sink_resolution)
+    ffd = topo.FlowObject(fdem, method=method, sink_resolution=sink_resolution)
 
     cd = cfd.downstream_distance()
     fd = ffd.downstream_distance()
 
     assert np.array_equal(cd, fd)
 
-def test_upstream_distance_order(order_dems):
+@pytest.mark.parametrize("method", ["d8"])
+@pytest.mark.parametrize("sink_resolution", ["carve", "lcat"])
+def test_upstream_distance_order(order_dems, method, sink_resolution):
     cdem, fdem = order_dems
 
-    cfd = topo.FlowObject(cdem)
-    ffd = topo.FlowObject(fdem)
+    cfd = topo.FlowObject(cdem, method=method, sink_resolution=sink_resolution)
+    ffd = topo.FlowObject(fdem, method=method, sink_resolution=sink_resolution)
 
     cd = cfd.upstream_distance()
     fd = ffd.upstream_distance()
@@ -306,8 +338,10 @@ def test_upstream_distance_order(order_dems):
 # array. Also check to make sure that dependencemap and influencemap
 # actually propagate values up and downstream by making sure there are
 # active pixels that are not part of the original mask
-def test_dependence_map_indexing(wide_dem):
-    fd = topo.FlowObject(wide_dem)
+@pytest.mark.parametrize("method", ["d8"])
+@pytest.mark.parametrize("sink_resolution", ["carve", "lcat"])
+def test_dependence_map_indexing(wide_dem, method, sink_resolution):
+    fd = topo.FlowObject(wide_dem, method=method, sink_resolution=sink_resolution)
 
     mask = wide_dem.z == np.min(wide_dem)
 
@@ -316,8 +350,10 @@ def test_dependence_map_indexing(wide_dem):
     assert np.any(d.z & np.invert(mask))
     assert wide_dem.z[d.z].size < wide_dem.z.size
 
-def test_influence_map_indexing(wide_dem):
-    fd = topo.FlowObject(wide_dem)
+@pytest.mark.parametrize("method", ["d8"])
+@pytest.mark.parametrize("sink_resolution", ["carve", "lcat"])
+def test_influence_map_indexing(wide_dem, method, sink_resolution):
+    fd = topo.FlowObject(wide_dem, method=method, sink_resolution=sink_resolution)
 
     mask = wide_dem.z == np.max(wide_dem)
 
@@ -327,41 +363,47 @@ def test_influence_map_indexing(wide_dem):
     assert np.any(i.z & np.invert(mask))
     assert wide_dem.z[i.z].size < wide_dem.z.size
 
-def test_dependence_map_order(order_dems):
+@pytest.mark.parametrize("method", ["d8"])
+@pytest.mark.parametrize("sink_resolution", ["carve", "lcat"])
+def test_dependence_map_order(order_dems, method, sink_resolution):
     cdem, fdem = order_dems
     l_c = cdem.duplicate_with_new_data(np.zeros(cdem.shape, dtype = bool, order = 'C'))
     l_f = fdem.duplicate_with_new_data(np.zeros(fdem.shape, dtype = bool, order = 'F'))
     l_c.z[50:100,50:100] = True
     l_f.z[50:100,50:100] = True
 
-    cfd = topo.FlowObject(cdem)
-    ffd = topo.FlowObject(fdem)
+    cfd = topo.FlowObject(cdem, method=method, sink_resolution=sink_resolution)
+    ffd = topo.FlowObject(fdem, method=method, sink_resolution=sink_resolution)
 
     cd = cfd.dependencemap(l_c)
     fd = ffd.dependencemap(l_f)
 
     assert np.array_equal(cd, fd)
 
-def test_influence_map_order(order_dems):
+@pytest.mark.parametrize("method", ["d8"])
+@pytest.mark.parametrize("sink_resolution", ["carve", "lcat"])
+def test_influence_map_order(order_dems, method, sink_resolution):
     cdem, fdem = order_dems
     l_c = cdem.duplicate_with_new_data(np.zeros(cdem.shape, dtype = bool, order = 'C'))
     l_f = fdem.duplicate_with_new_data(np.zeros(fdem.shape, dtype = bool, order = 'F'))
     l_c.z[50:100,50:100] = True
     l_f.z[50:100,50:100] = True
 
-    cfd = topo.FlowObject(cdem)
-    ffd = topo.FlowObject(fdem)
+    cfd = topo.FlowObject(cdem, method=method, sink_resolution=sink_resolution)
+    ffd = topo.FlowObject(fdem, method=method, sink_resolution=sink_resolution)
 
     cd = cfd.influencemap(l_c)
     fd = ffd.influencemap(l_f)
 
     assert np.array_equal(cd, fd)
 
-def test_getoutlets(wide_dem):
+@pytest.mark.parametrize("method", ["d8"])
+@pytest.mark.parametrize("sink_resolution", ["carve", "lcat"])
+def test_getoutlets(wide_dem, method, sink_resolution):
     # The outlets determined by FlowObject.getoutlets should be a
     # superset of those determined by s.streampoi('outlets')
 
-    fd = topo.FlowObject(wide_dem)
+    fd = topo.FlowObject(wide_dem, method=method, sink_resolution=sink_resolution)
     s = topo.StreamObject(fd, threshold=1)
 
     soutlets = s.streampoi('outlets')
@@ -374,12 +416,14 @@ def test_getoutlets(wide_dem):
 
     assert np.all(fog[sog])
 
-def test_getoutlets_order(order_dems):
+@pytest.mark.parametrize("method", ["d8"])
+@pytest.mark.parametrize("sink_resolution", ["carve", "lcat"])
+def test_getoutlets_order(order_dems, method, sink_resolution):
     # Identified outlets should be invariant of the memory ordering.
     cdem, fdem = order_dems
 
-    cfd = topo.FlowObject(cdem)
-    ffd = topo.FlowObject(fdem)
+    cfd = topo.FlowObject(cdem, method=method, sink_resolution=sink_resolution)
+    ffd = topo.FlowObject(fdem, method=method, sink_resolution=sink_resolution)
 
     coutlets = cfd.getoutlets()
     cog = np.zeros(cfd.shape, dtype=bool)
@@ -392,11 +436,13 @@ def test_getoutlets_order(order_dems):
     assert np.count_nonzero(cog) > 0
     assert np.array_equal(cog, fog)
 
-def test_vertdistance2stream_order(order_dems):
+@pytest.mark.parametrize("method", ["d8"])
+@pytest.mark.parametrize("sink_resolution", ["carve", "lcat"])
+def test_vertdistance2stream_order(order_dems, method, sink_resolution):
     cdem, fdem = order_dems
 
-    cfd = topo.FlowObject(cdem)
-    ffd = topo.FlowObject(fdem)
+    cfd = topo.FlowObject(cdem, method=method, sink_resolution=sink_resolution)
+    ffd = topo.FlowObject(fdem, method=method, sink_resolution=sink_resolution)
 
     cs = topo.StreamObject(cfd)
     fs = topo.StreamObject(ffd)


### PR DESCRIPTION
Resolves #421

This commit allows users to use the new libtopotoolbox functions for D8 routing with least cost auxiliary topography carving by passing `method="d8"` and `sink_resolution="lcat"` to the FlowObject constructor.

The default argument for "sink_resolution" is "carve", which applies the previous behavior. Nothing will change for users at the moment without explicit changes to user code. Eventually, we will probably deprecate the old behavior.

The new version (`FlowObject(method="d8", sink_resolution="lcat")`) will NOT produce identical results to (`FlowObject(method="d8", sink_resolution="carve")`) because of differences in the underlying libtopotoolbox implementation.

All of the FlowObject tests have been modified to also run with "d8" and "lcat", and they should pass.

The various flow routing functions are implemented as private functions of the flow_object module. Users should not call these functions but use the `FlowObject` constructor. It is highly likely that the implementation will need to change as we add different flow routing algorithms (Dinf, MFD, etc.), but the FlowObject constructor will always be the user-facing interface to flow routing.