### PR TITLE
Return the computed partial derivatives in evansslope

### DIFF
--- a/src/topotoolbox/grid_object.py
+++ b/src/topotoolbox/grid_object.py
@@ -950,8 +950,8 @@ class GridObject():
         if partial_derivatives:
             result_kx = cp.copy(self)
             result_ky = cp.copy(self)
-            result_kx.z = kx
-            result_ky.z = ky
+            result_kx.z = fx
+            result_ky.z = fy
             return result_kx, result_ky
 
         slope = np.sqrt(fx**2 + fy**2)

--- a/tests/test_grid_object.py
+++ b/tests/test_grid_object.py
@@ -75,6 +75,8 @@ def types_dems():
 
     return [dem32, dem64]
 
+def rotGrid90(dem):
+    return dem.duplicate_with_new_data(np.rot90(dem))
 
 def test_fillsinks(square_dem, wide_dem, tall_dem):
     # TODO: add more tests
@@ -330,6 +332,18 @@ def test_erode_order(order_dems):
 
     assert np.array_equal(ceroded, feroded)
 
+@pytest.mark.parametrize("modified", [True, False])
+def test_evansslope_rotation(square_dem, modified):
+    g = square_dem.evansslope(modified=modified)
+    r = rotGrid90(square_dem).evansslope(modified=modified)
+
+    assert np.allclose(rotGrid90(g), r)
+
+    gx, gy = square_dem.evansslope(modified=modified, partial_derivatives=True)
+    rx, ry = rotGrid90(square_dem).evansslope(modified=modified, partial_derivatives=True)
+
+    assert np.allclose(rotGrid90(gx).z, ry.z)
+    assert np.allclose(rotGrid90(gy).z, -rx.z)
 
 @pytest.mark.parametrize("modified", [True, False])
 def test_evansslope_order(order_dems, modified):


### PR DESCRIPTION
GridObject.evansslope previously returned the two gradient filters rather than the filtered DEM.

A test is added to verify that this works. The test is a metamorphic test that rotates the DEM and compares the gradients to make sure that they transform as expected.