### PR TITLE
Add a FlowObject.grid method

### DIFF
--- a/src/topotoolbox/flow_object.py
+++ b/src/topotoolbox/flow_object.py
@@ -329,6 +329,43 @@ class FlowObject():
 
         return k.astype(dtype)
 
+    def grid(self, z, **kwargs):
+        """Construct a GridObject aligned with the FlowObject from an array of data.
+
+        Keyword arguments are forwarded to a call to
+        `numpy.asarray`. Use these keyword arguments to specify the
+        data type (`dtype`) or whether to make a copy (`copy: bool`),
+        for example.
+
+        Parameters
+        ----------
+
+        z: array_like
+           An array or other object that exposes the Numpy array
+           interface (e.g. a `GridObject`).
+
+        Raises
+        ------
+        ValueError
+            The input array is not appropriated shaped for the `FlowObject`
+
+        """
+        if not validate_alignment(self, z):
+            raise ValueError("Input is not properly aligned to the FlowObject")
+
+        result = GridObject()
+        result.path = self.path
+        result.name = self.name
+
+        result.z = np.asarray(z, **kwargs)
+        result.cellsize = self.cellsize
+
+        result.bounds = self.bounds
+        result.transform = self.transform
+        result.georef = self.georef
+
+        return result
+
     def flow_accumulation(self, weights: np.ndarray | float = 1.0):
         """Computes the flow accumulation for a given flow network using
         optional weights. The flow accumulation represents the amount of flow
@@ -372,18 +409,7 @@ class FlowObject():
 
         _stream.traverse_down_f32_add_mul(acc, fraction, self.source, self.target)
 
-        result = GridObject()
-        result.path = self.path
-        result.name = self.name
-
-        result.z = acc
-        result.cellsize = self.cellsize
-
-        result.bounds = self.bounds
-        result.transform = self.transform
-        result.georef = self.georef
-
-        return result
+        return self.grid(acc)
 
     def getoutlets(self):
         """Extract outlets from a flow network.
@@ -458,18 +484,7 @@ class FlowObject():
         _stream.traverse_up_u32_or_and(
             basins, weights, self.source, self.target)
 
-        result = GridObject()
-        result.path = self.path
-        result.name = self.name
-
-        result.z = np.array(basins, dtype=np.int64)
-        result.cellsize = self.cellsize
-
-        result.bounds = self.bounds
-        result.transform = self.transform
-        result.georef = self.georef
-
-        return result
+        return self.grid(basins, dtype=np.int64)
 
     def flowpathextract(self, idx: int):
         """Extract linear indices of a single flowpath in a DEM
@@ -544,18 +559,7 @@ class FlowObject():
         down_d = np.zeros(self.shape, dtype = np.float32, order=self.order)
         _stream.traverse_down_f32_max_add(down_d, dist, self.source, self.target)
 
-        result = GridObject()
-        result.path = self.path
-        result.name = self.name
-
-        result.z = down_d
-        result.cellsize = self.cellsize
-
-        result.bounds = self.bounds
-        result.transform = self.transform
-        result.georef = self.georef
-
-        return result
+        return self.grid(down_d)
 
     def upstream_distance(self) -> GridObject:
         """Calculates the horizontal distance from outlets and ridges
@@ -572,18 +576,7 @@ class FlowObject():
         up_d = np.zeros(self.shape, dtype = np.float32, order=self.order)
         _stream.traverse_up_f32_max_add(up_d, dist, self.source, self.target)
 
-        result = GridObject()
-        result.path = self.path
-        result.name = self.name
-
-        result.z = up_d
-        result.cellsize = self.cellsize
-
-        result.bounds = self.bounds
-        result.transform = self.transform
-        result.georef = self.georef
-
-        return result
+        return self.grid(up_d)
 
     def vertdistance2stream(self, stream,
                                       grid: GridObject) -> GridObject:
@@ -647,7 +640,7 @@ class FlowObject():
         i = np.ones(self.source.shape, dtype = np.uint8, order=self.order) # turns on all edges
         _stream.traverse_up_u8_or_and(seed, i, self.source, self.target)
 
-        return l.duplicate_with_new_data(np.asarray(seed, dtype=np.bool))
+        return self.grid(seed, dtype=np.bool)
 
     def influencemap(self, l) -> GridObject:
         """Delineate downslope area for specific locations in a DEM.
@@ -671,7 +664,7 @@ class FlowObject():
         i = np.ones(self.source.shape, dtype = np.uint8, order=self.order) # turns on all edges
         _stream.traverse_down_u8_or_and(seed, i, self.source, self.target)
 
-        return l.duplicate_with_new_data(np.asarray(seed, dtype=np.bool))
+        return self.grid(seed, dtype=np.bool)
 
     # 'Magic' functions:
     # ------------------------------------------------------------------------

--- a/tests/test_flow_object.py
+++ b/tests/test_flow_object.py
@@ -79,6 +79,30 @@ def test_flowobject_order(order_dems, method, sink_resolution):
 
     assert isequivalent(cfd, ffd)
 
+def test_flowobject_grid(wide_dem):
+    fd = topo.FlowObject(wide_dem)
+
+    z = fd.grid(wide_dem)
+    assert np.array_equal(z, wide_dem)
+
+    assert z.georef == wide_dem.georef
+    assert z.bounds == wide_dem.bounds
+
+    z = fd.grid(wide_dem, dtype=np.int64)
+    assert z.z.dtype == np.int64
+
+    z = fd.grid(wide_dem, copy=True)
+    z[0, 0] = np.nan
+    assert not np.isnan(wide_dem.z[0, 0])
+
+    assert np.array_equal(fd.grid(wide_dem), fd.grid(wide_dem, copy=True))
+
+    a = np.zeros(fd.shape, dtype=np.float32)
+
+    z = fd.grid(a, dtype=np.float32, copy=False)
+    a[0, 0] = 1.0
+    assert z[0, 0] == 1.0
+
 @pytest.mark.parametrize("method", ["d8"])
 @pytest.mark.parametrize("sink_resolution", ["carve", "lcat"])
 def test_flow_accumulation_order(order_dems, method, sink_resolution):
@@ -345,8 +369,7 @@ def test_dependence_map_indexing(wide_dem, method, sink_resolution):
 
     mask = wide_dem.z == np.min(wide_dem)
 
-    l = wide_dem.duplicate_with_new_data(mask)
-    d = fd.dependencemap(l)
+    d = fd.dependencemap(mask)
     assert np.any(d.z & np.invert(mask))
     assert wide_dem.z[d.z].size < wide_dem.z.size
 
@@ -357,8 +380,7 @@ def test_influence_map_indexing(wide_dem, method, sink_resolution):
 
     mask = wide_dem.z == np.max(wide_dem)
 
-    l = wide_dem.duplicate_with_new_data(mask)
-    i = fd.influencemap(l)
+    i = fd.influencemap(mask)
 
     assert np.any(i.z & np.invert(mask))
     assert wide_dem.z[i.z].size < wide_dem.z.size


### PR DESCRIPTION
This method is meant to be similar to the GRIDobj(FD, Z) constructor in MATLAB. It is added as a FlowObject method, though, because the source flow object is where all of the metadata comes from.

It copies metadata from the source flow object and then stores the provided array.

Any keyword arguments are forwarded to numpy.asarray. This is simpler than including all the possible keyword arguments to asarray, which would also require additional maintenance if such arguments change.

A test is added that runs FlowObject.grid with a few different keyword arguments and makes sure that copies are created or not and that the data types are as expected.

The FlowObject methods that produce
GridObjects (e.g. flow_accumulation, drainagebasins) now use FlowObject.grid to construct their result.

A side effect of this change is that FlowObject.influencemap and FlowObject.dependencemap can now accept numpy arrays rather than GridObjects. Previously, they used the source GridObject to construct their results. This would error if a raw numpy array was passed. It is quite common to construct such an array as a mask, and it is a little annoying to remember to call `duplicate_with_new_data` before calling `influencemap`. The {influencemap, dependencemap}_indexing tests are updated to use a raw numpy array as an input to make sure that this functionality works as expected.