### PR TITLE
Add PPS class implementation

### DIFF
--- a/src/topotoolbox/__init__.py
+++ b/src/topotoolbox/__init__.py
@@ -6,6 +6,7 @@ from .flow_object import FlowObject, EdgeSet
 from .stream_object import StreamObject
 from .graphflood_object import GFObject
 from .graphflood import *
+from .pps import PPS
 from .utils import *
 from .stream_functions import *
 from .swath import *

--- a/src/topotoolbox/pps.py
+++ b/src/topotoolbox/pps.py
@@ -1,0 +1,41 @@
+"""Tools for analyzing point patterns on stream networks
+"""
+
+from dataclasses import dataclass
+
+import numpy as np
+import numpy.typing as npt
+
+from .stream_object import StreamObject
+
+
+@dataclass
+class PPS:
+    """Point pattern on stream network
+
+    An instance of PPS stores a stream network (StreamObject) and an
+    associated point pattern.
+
+    Implementation
+    --------------
+
+    Unlike the MATLAB implementation, a PPS stores a logical node
+    attribute list indicating the presence or absence of a point on
+    each node in the stream network.
+
+    """
+
+    s: StreamObject
+    pp: npt.NDArray[np.intp]
+
+    @property
+    def npoints(self) -> int:
+        """The number of points in the point pattern
+        """
+        return self.pp.size
+
+    @classmethod
+    def from_nal(cls, stream: StreamObject, nal: npt.NDArray[bool]):
+        """Construct a PPS from a logical node attribute list
+        """
+        return cls(stream, np.flatnonzero(nal))

--- a/src/topotoolbox/pps.py
+++ b/src/topotoolbox/pps.py
@@ -35,7 +35,7 @@ class PPS:
         return self.pp.size
 
     @classmethod
-    def from_nal(cls, stream: StreamObject, nal: npt.NDArray[bool]):
+    def from_nal(cls, stream: StreamObject, nal: npt.NDArray[np.bool]):
         """Construct a PPS from a logical node attribute list
         """
         return cls(stream, np.flatnonzero(nal))

--- a/tests/test_pps.py
+++ b/tests/test_pps.py
@@ -1,0 +1,17 @@
+import pytest
+
+import numpy as np
+import topotoolbox as tt3
+
+@pytest.fixture(name="stream")
+def fixture_stream():
+    dem = tt3.gen_random(rows=64, columns=128)
+    fd = tt3.FlowObject(dem)
+    s = tt3.StreamObject(fd)
+    return s
+
+def test_pps(stream):
+    nal = stream.downstream_distance() > 10
+    pps = tt3.PPS.from_nal(stream, nal)
+
+    assert pps.npoints == np.count_nonzero(nal)


### PR DESCRIPTION
This is the counterpart to the Point Pattern on Stream networks class from MATLAB.

I am taking a slightly different approach with PPS to the other classes. The PPS class is a dataclass, so basically a plain old data struct, that contains a StreamObject and an array identifying points. The PPS constructor therefore always takes a StreamObject and an array with the points. More sophisticated constructors for random sampling, etc. will be implemented as separate classmethods/functions such as PPS.from_nal here.

The npoints method is added to give us something to test.

A test is added that creates a PPS from a logical node attribute list and counts the number of points.