### PR TITLE
Use actions from the TopoToolbox/actions repository

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,9 +14,9 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: TopoToolbox/actions/checkout
+        uses: TopoToolbox/actions/checkout@main
       - name: Set up Python
-        uses: TopoToolbox/actions/setup-python
+        uses: TopoToolbox/actions/setup-python@main
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -39,10 +39,10 @@ jobs:
     steps:
 
       - name: Checkout
-        uses: TopoToolbox/actions/checkout
+        uses: TopoToolbox/actions/checkout@main
 
       - name: Setup Python
-        uses: TopoToolbox/actions/setup-python
+        uses: TopoToolbox/actions/setup-python@main
 
       - name: Install tools
         run: pip install -r requirements.txt
@@ -56,9 +56,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: TopoToolbox/actions/checkout
+        uses: TopoToolbox/actions/checkout@main
       - name: Restore data cache
-        uses: TopoToolbox/actions/cache
+        uses: TopoToolbox/actions/cache@main
         with:
           path: ~/.cache/topotoolbox
           key: tt3-docs-data
@@ -80,7 +80,7 @@ jobs:
           make clean
           make html
       - name: Upload documentation as a build artifact
-        uses: TopoToolbox/actions/upload-artifact
+        uses: TopoToolbox/actions/upload-artifact@main
         with:
           name: docs
           path: ${{ github.workspace }}/docs/_build/html

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,10 +14,9 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
+        uses: TopoToolbox/actions/checkout
       - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        uses: TopoToolbox/actions/setup-python
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -40,10 +39,10 @@ jobs:
     steps:
 
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: TopoToolbox/actions/checkout
 
       - name: Setup Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        uses: TopoToolbox/actions/setup-python
 
       - name: Install tools
         run: pip install -r requirements.txt
@@ -57,9 +56,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: TopoToolbox/actions/checkout
       - name: Restore data cache
-        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        uses: TopoToolbox/actions/cache
         with:
           path: ~/.cache/topotoolbox
           key: tt3-docs-data
@@ -81,7 +80,7 @@ jobs:
           make clean
           make html
       - name: Upload documentation as a build artifact
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: TopoToolbox/actions/upload-artifact
         with:
           name: docs
           path: ${{ github.workspace }}/docs/_build/html

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: TopoToolbox/actions/checkout@main
 
       - name: Restore data cache
-        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        uses: TopoToolbox/actions/cache@main
         with:
           path: ~/.cache/topotoolbox
           key: tt3-docs-data
@@ -39,7 +39,7 @@ jobs:
           make html
 
       - name: Package artifact
-        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
+        uses: TopoToolbox/actions/upload-pages-artifact@main
         with:
           path: ${{ github.workspace }}/docs/_build/html
 
@@ -56,4 +56,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0
+        uses: TopoToolbox/actions/deploy-pages@main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,8 +10,8 @@ jobs:
     name: Make SDist
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+      - uses: TopoToolbox/actions/checkout@main
+      - uses: TopoToolbox/actions/setup-python@main
 
       - name: Install build
         run: python -m pip install build
@@ -19,7 +19,7 @@ jobs:
       - name: Build SDist
         run: python -m build --sdist
 
-      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+      - uses: TopoToolbox/actions/upload-artifact@main
         with:
           name: cibw-sdist
           path: dist/*.tar.gz
@@ -35,8 +35,8 @@ jobs:
         cibw_arch: ["native"]
         cibw_build: ["cp311-* cp312-* cp313-* cp314-*"]
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+      - uses: TopoToolbox/actions/checkout@main
+      - uses: TopoToolbox/actions/setup-python@main
 
       - name: Install cibuildwheel
         run: python -m pip install cibuildwheel==2.21.3
@@ -61,7 +61,7 @@ jobs:
           CIBW_ENVIRONMENT_LINUX: PIP_ONLY_BINARY=":all:"
           CIBW_TEST_ENVIRONMENT_LINUX: PIP_ONLY_BINARY=":all:"
 
-      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+      - uses: TopoToolbox/actions/upload-artifact@main
         with:
           name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}
           path: ./wheelhouse/*.whl
@@ -74,7 +74,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      - uses: TopoToolbox/actions/download-artifact@main
         with:
           pattern: cibw-*
           path: dist
@@ -94,12 +94,12 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      - uses: TopoToolbox/actions/download-artifact@main
         with:
           pattern: cibw-*
           path: dist
           merge-multiple: true
       - name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
+        uses: TopoToolbox/actions/gh-action-pypi-publish@main
         with:
           verbose: true


### PR DESCRIPTION
We don't use a version number/commit SHA because we control that from
the TopoToolbox/actions repository.

The other workflows have not been updated to make sure that this
works.